### PR TITLE
Log owner of current tty

### DIFF
--- a/snoopy.c
+++ b/snoopy.c
@@ -52,7 +52,7 @@ static inline void snoopy_log(const char *filename, char *const argv[])
 
 	char   *ttyPath         = NULL; 
 	char    ttyPathEmpty[]  = ""; 
-	long    ttyUid          = 0;
+	long    ttyUid          = -1;
 
 	#if defined(SNOOPY_EXTERNAL_FILTER)
 		FILE   *fp;


### PR DESCRIPTION
Added UID of current TTY, as a means of tracking actual user ID as opposed to current user ID.

In effect, this matches the behavior seen with the "auid" field in auditd -- although this isn't guaranteed to be accurate, I can't come up with a normal workflow where this doesn't match.

I had considered setting tty_uid to -1 when no TTY device is present, but if tty field is blank, it seems pretty apparent that tty_uid would also be meaningless.
