### PR TITLE
Prevent compile error in cwd.c:

### DIFF
--- a/src/input/cwd.c
+++ b/src/input/cwd.c
@@ -45,7 +45,7 @@ int snoopy_input_cwd (char *input, char *arg)
 {
     char cwdBuf[PATH_MAX+1];
 
-    getcwd(cwdBuf, PATH_MAX+1);
-
-    return snprintf(input, SNOOPY_INPUT_MESSAGE_MAX_SIZE, "%s", cwdBuf);
+    if(getcwd(cwdBuf, PATH_MAX+1))
+      return snprintf(input, SNOOPY_INPUT_MESSAGE_MAX_SIZE, "%s", cwdBuf);
+    return -1;
 }


### PR DESCRIPTION
getcwd result must be used in some way.

cwd.c: In function 'snoopy_input_cwd':
cwd.c:48:11: error: ignoring return value of 'getcwd', declared with attribute warn_unused_result [-Werror=unused-result]
cc1: all warnings being treated as errors
