### PR TITLE
Initial commit of RHEL/CentOS compatible RPM SPEC file

### DIFF
--- a/contrib/rhel/snoopy.spec
+++ b/contrib/rhel/snoopy.spec
@@ -1,0 +1,37 @@
+Name:           snoopy
+Version:        2.0.0rc12
+Release:        1%{?dist}
+Summary:        Snoopy is a wrapper around execve() that logs all executed commands by all users and processes to syslog.
+License:        GPLv2
+URL:            https://github.com/a2o/snoopy
+Source0:        snoopy-2.0.0rc12.tar.gz
+
+%description
+Snoopy is designed to aid a sysadmin by providing a log of commands executed. Snoopy is completely transparent to the user and applications. It is linked into programs to provide a wrapper around calls to execve(). Logging is done via syslog.
+
+%prep
+%autosetup
+
+%build
+%configure
+make %{?_smp_mflags}
+
+%install
+%make_install
+
+mkdir %{buildroot}/etc
+install -m 0644 etc/snoopy.ini %{buildroot}/%{_sysconfdir}/snoopy.ini
+
+%files
+%doc ChangeLog COPYING
+%{_bindir}/*
+%{_libdir}/*
+%{_sbindir}/*
+%{_sysconfdir}/*
+
+%post -p /usr/sbin/snoopy-enable
+%preun -p /usr/sbin/snoopy-disable
+
+%changelog
+* Tue Nov 4 2014 Jeremy Brown <jwbrown77@yahoo.com> 2.0.0rc12-1
+- Initial RPM spec for snoopy.


### PR DESCRIPTION
Hi Bostjan,

This is my initial attempt at an RHEL/CentOS spec file.  I noticed that the SLES spec in your repo seems based around building from a git checkout, where mine is more based on an official release tarball.

I'm not exactly sure what you're looking for, so I just kept this as simple as possible.  I tested building, installing, and uninstalling on CentOS 7 and can confirm all work, including enabling/disabling on install/uninstall as you requested.

Let me know if there's anything else I can do to help.

Thanks,

Jeremy
