### PR TITLE
Feature/filter exclude spawns of 

### DIFF
--- a/contrib/debian/changelog
+++ b/contrib/debian/changelog
@@ -1,8 +1,9 @@
-snoopy (2:2.0.1rc1) UNRELEASED; urgency=medium
+snoopy (2:2.0.1rc3) UNRELEASED; urgency=medium
 
   * Bump version.
+  * Change build options to enable filtering and config file.
 
- -- Fred Mora <fmora@datto.com>  Thu, 23 Apr 2015 20:41:58 -0400
+ -- Fred Mora <fmora@datto.com>  Fri, 24 Apr 2015 18:27:42 -0400
 
 snoopy (2:2.0.0rc5-1) unstable; urgency=low
 

--- a/contrib/debian/changelog
+++ b/contrib/debian/changelog
@@ -1,3 +1,9 @@
+snoopy (2:2.0.1rc1) UNRELEASED; urgency=medium
+
+  * Bump version.
+
+ -- Fred Mora <fmora@datto.com>  Thu, 23 Apr 2015 20:41:58 -0400
+
 snoopy (2:2.0.0rc5-1) unstable; urgency=low
 
   * Bump to version 2.0.0rc5.

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -20,6 +20,8 @@ override_dh_auto_configure:
 		--libexecdir=\${prefix}/lib/snoopy \
 		--disable-maintainer-mode \
 		--disable-dependency-tracking \
+		--enable-filter \
+		--enable-config-file \
 		--with-message-format='[login:%{login} ssh:(%{env:SSH_CONNECTION}) sid:%{sid} tty:%{tty} (%{tty_uid}/%{tty_username}) uid:%{username}(%{uid})/%{eusername}(%{euid}) gid:%{group}(%{gid})/%{egroup}(%{egid}) cwd:%{cwd}]: %{cmdline}'
 
 

--- a/doc/FILTER_exclude_spawns_of.md
+++ b/doc/FILTER_exclude_spawns_of.md
@@ -1,0 +1,120 @@
+# The exclude_spawns_of filter
+
+## Purpose of the filter
+
+When snoopy is installed, it will generate a log message for every executable
+that runs. This includes the programs invoked by cron and other system
+daemons. All these messages create noise in the logs and tends to drown useful
+information. So filtering out messages created by cron jobs is therefore a
+useful feature. That's what the exclude_spawns_of filter does.
+
+## Terms used
+
+In this page, we use the following terms:
+
+- Process tree: this is the graph of processes running on your system, starting at init (process 1) at the top, and going down from parent to child processes.
+- Ancestor: A process _A_ is the ancestor of process _P_ if you can start from _P_ in the process tree and go up one or more levels until you find _A_.
+- Descendant: A process _D_ is a descendant of process _P_ if _P_ is the ancestor of _D_. A synonym for _spawn_.
+
+
+## Setting up the filter
+
+The filter takes a comma-separated list of program names as a parameter. If the current process is a descendant of one of the named programs, the filter will drop the message.
+
+So if you want to avoid logging programs executed by cron jobs or their descendants, just put
+
+    filter_chain = "exclude_spawns_of:cron"
+
+in the `snoopy.ini` file.
+
+The list of program names after the `exclude_spawns_of:` is called the _black list_. It is a list of ancestors for which the log message should be dropped.
+
+Of course, your filter chain can include other filters. See snoopy.ini for examples.
+
+If you also want to avoid logging the executables launched by `mydaemon`, you can add it to the black list:
+
+    filter_chain = "exclude_spawns_of:cron,mydaemon"
+
+Do not put spaces around the colon or the commas!
+
+## The gory details
+
+The filter walks up the process tree and examines the ancestors of the current process, starting from the parent of the current process. For each ancestor, the filter compares the name of the executable with the black list. If there is a match, the filter drops the message.
+
+A name listed in the black list can be a binary name or a script name. If you have a doubt, find the program that you want to add in the list and run the command
+
+    cat /proc/nnnn/stat
+
+where _nnnn_ is the PID of the program. The output of the command will list a name between parentheses in the second word. That name (without the parentheses!) is what you need to add in the black list.
+
+If the filter encounters an error, it will pass the message.
+
+## Installing and testing the filter
+
+### Compiling
+
+If you install from source, make sure that the following options are passed to `./configure`:
+
+    --enable-filter
+    --enable-config-file
+
+For debian, these options are in `debian/rules`.
+
+### Installing
+
+The filter is installed along with the rest of snoopy, there is no separate package.
+
+### Setting up
+
+We assume you are running as root or sudoing as needed.
+
+If you installed from a package that was correctly configured, you should see the file `/etc/snoopy.ini` in your system. If this file is missing, it means that the version of snoopy you installed was compiled without the `--enable-config-file` option. It cannot be used here. Please install a different version.
+
+ We are going to modify the ini file to make sure the filter works.
+
+Change the default message format in `/etc/snoopy.ini`. For example, we add the PID of the process:
+
+    message_format =  "[pid:%{pid} uid:%{uid} sid:%{sid} tty:%{tty} cwd:%{cwd} filename:%{filename}]: %{cmdline}"
+
+Next, we will create an easy-to-test black list. Add the following line in  `/etc/snoopy.ini`:
+
+    filter_chain = "exclude_spawns_of:cron,sh"
+
+We specified that snoopy should not log programs spawned by cron and sh. We assume here that you run bash as the standard shell. You can verify that this is the case with the command:
+
+    getent passwd $USER
+
+The last string in the command output is your login shell, `bash` by default.
+
+### Verifying that snoopy reads the ini file
+
+Let's enable snoopy with the command:
+
+    snoopy-enable
+
+You can check that the `/etc/ld.so.preload` file now contains something like `/lib/libsnoopy.so`.
+
+Open another window and run `tail -f /var/log/auth.log` to check that snoopy works.
+
+Snoopy works only for processes started after it's enabled, so let's invoke a new shell with the command
+
+    bash
+
+Within that new shell, run ls. You will see a message in `auth.log` that looks like this:
+```
+Apr 24 21:41:57 fred-vm-ub1 snoopy[2320]: [pid:2320 uid:1000 sid:1872 tty:/dev/pts/0 cwd:/home/fmora filename:/bin/ls]: ls
+```
+
+This shows that snoopy read the ini file and parsed the `message_format` parameter.
+
+### Testing the filter
+
+Remember that your default shell is bash, and that you added the `sh` shell to the black list. So let's run the command `sh` to start an instance of this shell. You should see that snoopy records it in the log (since its ancestors are not blacklisted).
+
+However, type `ls` or other commands within the new `sh` shell. You should see that snoopy does not log these commands, since they are a descendant of the blacklisted `sh`.
+
+Start a bash shell within sh by typing `bash`. Within bash, type `ls` or other commands. Snoopy does not log them. This is because these commands are still descendants from the blacklisted `sh`.
+
+This shows that the filter works. You can now set the black list as you need.
+
+

--- a/etc/snoopy.ini
+++ b/etc/snoopy.ini
@@ -51,6 +51,7 @@
 ; - filter_chain = "exclude_uid:0"       # Log all commands, except the ones executed by root
 ; - filter_chain = "exclude_uid:1,2,3"   # Log all commands, except those executed by users with UIDs 1, 2 and 3
 ; - filter_chain = "only_uid:0"          # Log only root commands
+; - filter_chain = "exclude_spawns_of:cron,my_daemon" # Do not log commands spawned by cron or my_daemon
 ; - filter_chain = "filter1:arg11;filter2:arg21,arg22;filter3:arg31,32,33"
 ;
 ; Here you have four filter definitions for your reference, they are

--- a/src/filter/Makefile.am
+++ b/src/filter/Makefile.am
@@ -21,6 +21,7 @@ noinst_LTLIBRARIES = libsnoopy_filters_all.la
 # Please maintain alphabetical order, equal to what `ls` would do
 #
 libsnoopy_filters_all_la_SOURCES = \
+	exclude_spawns_of.c \
 	exclude_uid.c \
 	exclude_uid.h \
 	only_root.c \

--- a/src/filter/exclude_spawns_of.c
+++ b/src/filter/exclude_spawns_of.c
@@ -44,10 +44,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
-#include <sys/stat.h>
 #include <unistd.h>
 
 #define PROGLISTSEP ','
+
+int find_ancestor_in_list(char **name_list);
+int find_string_in_array(char *str, char **str_array);
+char **string_to_token_array(char *str);
 
 int snoopy_filter_exclude_spawns_of(char *msg, char *arg)
 {
@@ -82,7 +85,6 @@ int snoopy_filter_exclude_spawns_of(char *msg, char *arg)
  */
 int find_ancestor_in_list(char **name_list)
 {
-    struct stat st;
     pid_t ppid;
     char stat_path[32]; // Path "/proc/nnnn/stat" where nnnn = some PID
     FILE *statf;

--- a/src/filter/exclude_spawns_of.c
+++ b/src/filter/exclude_spawns_of.c
@@ -67,7 +67,7 @@ int snoopy_filter_exclude_spawns_of(char *msg, char *arg)
     // Check if one of the program names in losp is an ancestor
     is_ancestor_in_list = find_ancestor_in_list(losp);
     free(losp);
-    return (is_ancestor_in_list == 0) ? SNOOPY_FILTER_PASS : SNOOPY_FILTER_DROP; // Error means pass
+    return (is_ancestor_in_list == 1) ? SNOOPY_FILTER_DROP : SNOOPY_FILTER_PASS; // Error means pass
 }
 
 // Helper functions

--- a/src/filter/exclude_spawns_of.c
+++ b/src/filter/exclude_spawns_of.c
@@ -1,0 +1,202 @@
+/*
+ * SNOOPY LOGGER
+ *
+ * File: snoopy/filter/exclude_spawns_of.c
+ *
+ * Copyright (c) 2015 Datto, Inc. All rights reserved.
+ * Author: Fred Mora - fmora@datto.com
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+
+/*
+ * SNOOPY FILTER: exclude_spawns_of
+ *
+ * Description:
+ *     Excludes all log messages for executables that have the specified program name in their ancestors.
+ *     Strategy: We parse arg to create the "list of specified programs" (LoSP).
+ *     Then, we walk up the parent process ID (PPID) chain and we check if each executable name is part
+ *     of the LoSP.
+ *
+ * Params:
+ *     logMessage: Pointer to string that contains formatted log message (may be manipulated)
+ *     arg:        Comma-separated list of program names for the spawns of which log messages are dropped.
+ *
+ * Return:
+ *     SNOOPY_FILTER_PASS or SNOOPY_FILTER_DROP
+ */
+
+#include "snoopy.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#define PROGLISTSEP ','
+
+int snoopy_filter_exclude_spawns_of(char *msg, char *arg)
+{
+    char **losp; // List of specified programs derived from arg
+    int is_ancestor_in_list = 0;
+
+    // Turn comma-separated arg into array of program name strings
+    losp = string_to_token_array(arg);
+    if (losp == NULL) {
+	// If failure, we cannot filter anything, just pass the message
+	return SNOOPY_FILTER_PASS;
+    }
+
+    // Check if one of the program names in losp is an ancestor
+    is_ancestor_in_list = find_ancestor_in_list(losp);
+    free(losp);
+    return (is_ancestor_in_list == 0) ? SNOOPY_FILTER_PASS : SNOOPY_FILTER_DROP; // Error means pass
+}
+
+// Helper functions
+
+/**
+ * Description:
+ *    Walks the /proc tree from /proc/currentPID and iterate parent PIDs up to PID 1. For each PID, check if the
+ *    executable name is in name_list.
+ * Params:
+ *    name_list: Ptr to array of char ptr. Each element point to the name of an executable.
+ * Return:
+ *    1 if the executable name of an ancestor process is found in name_list
+ *    0 if there are no ancestor that have a name found in name_list
+ *   -1 if error.
+ */
+int find_ancestor_in_list(char **name_list)
+{
+    struct stat st;
+    pid_t ppid;
+    char stat_path[32]; // Path "/proc/nnnn/stat" where nnnn = some PID
+    FILE *statf;
+    int rc, found;
+    char *ancestor_name;
+    // The following var are read from /proc/nnnn/stat
+    char *st_comm; //Exec file name. Points to buffer that will be malloc'd.
+    pid_t st_pid;
+    char st_state;
+
+    if (name_list == NULL) {
+	return -1;
+    }
+    ppid = getppid(); // We start with the parent
+    while (ppid != 1) {
+	// Create the path to /proc/<ppid>/stat
+	sprintf(stat_path, "/proc/%d/stat", ppid);
+	statf = fopen(stat_path, "r");
+	if (statf == NULL) {
+	    return -1;
+	}
+
+	// Grab the first few elements from the stat pseudo-file. Format from man 5 proc.
+	rc = fscanf(statf, "%d %ms %c %d", &st_pid, &st_comm, &st_state, &ppid);
+	if (rc == EOF) {
+	    return -1;
+	}
+	// stat provides st_comm as the name between parentheses. Get rid of the parens.
+	ancestor_name = st_comm + 1;
+	st_comm[strlen(st_comm) - 1] = '\0';
+	found = find_string_in_array(ancestor_name, name_list);
+
+	free(st_comm);
+	if (found) {
+	    return 1;
+	}
+    } 
+
+    return 0; // Nothing found
+}
+
+/**
+ * Description:
+ *    Searches for a string in an array of strings. All strings are zero-terminated.
+ * Params:
+ *    str: Ptr to the string we are looking for in str_array.
+ *    str_array: Ptr to array of char ptr, each of them pointing to a string to compare to str.
+ * Return:
+ *    1 if str matches one of the strings in str_array
+ *    0 if there are no matches or if either argument is NULL.
+ */
+int find_string_in_array(char *str, char **str_array)
+{
+    if ((str == NULL) || (str_array == NULL)) {
+	return 0;
+    }
+    char **p = str_array;
+    while (*p != NULL) {
+	if (strcmp(str, *p) == 0) {
+	    return 1;
+	}
+	p++;
+    }
+    return 0;
+}
+
+/**
+ * Description:
+ *    Tokenizes string str using comma as a separator. Returns an array of individual tokens between delimiters.
+ *
+ * Params:
+ *    str: string to be tokenized. The string is modified as per strtok (delimiters replaced with \0)..
+ * Returns:
+ *    Ptr to array of char ptr. Each element point to an individual substring between delimiters.
+ *    The last element is the NULL pointer to act as a delimiter.
+ *    The returned pointer should be freed by the caller after use.
+ *    If str is NULL or empty, or if error, returns NULL.
+ */
+
+char **string_to_token_array(char *str)
+{
+    char *p;
+    int i;
+    int sepcount = 0;
+    int token_count;
+    char **token_array; // Return value
+    char *saveptr = NULL; // For strtok_r()
+
+    if ((str == NULL) || (*str == '\0')) {
+	return NULL;
+    }
+
+    // Count the occurences of PROGLISTSEP
+    p = strchr(str, PROGLISTSEP);
+    while (p != NULL) {
+	sepcount++;
+	p=strchr(p+1, PROGLISTSEP);
+    }
+
+    // Allocate storage for token_array: one more than the separator count, and one more for the NULL delimiter.
+    token_count = sepcount +1;
+    token_array = calloc(token_count + 1, sizeof(p));
+    if (token_array == NULL) {
+	return NULL;
+    }
+
+    // Fill in token_array with ptrs to individual tokens
+    char delim[] = { PROGLISTSEP, '\0'}; // Make a string of delimiters
+    p = str;
+    for (i = 0; i < token_count; i++) {
+	token_array[i] = strtok_r(p, delim, &saveptr);
+	p = NULL;
+    }
+    token_array[token_count] = NULL;
+    return(token_array);
+}
+

--- a/src/filter/exclude_spawns_of.h
+++ b/src/filter/exclude_spawns_of.h
@@ -1,9 +1,10 @@
 /*
  * SNOOPY LOGGER
  *
- * File: filterregistry.h
+ * File: snoopy/filter/exclude_spawns_of.h
  *
- * Copyright (c) 2014 bostjan@a2o.si
+ * Copyright (c) 2015 Datto, Inc. All rights reserved.
+ * Author: Fred Mora - fmora@datto.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,26 +24,6 @@
 
 
 /*
- * Include headers of all filter functions
+ * SNOOPY FILTER: exclude_spawns_of
  */
-#include "filter/exclude_spawns_of.h"
-#include "filter/exclude_uid.h"
-#include "filter/only_root.h"
-#include "filter/only_uid.h"
-
-
-
-/*
- * Two arrays holding data about filter functions
- */
-extern char *snoopy_filterregistry_names[];
-extern int (*snoopy_filterregistry_ptrs []) (char *logMessage, char *arg);
-
-
-
-/*
- * Functions to manage and utilise filter providers
- */
-int snoopy_filterregistry_call         (char *filterName, char *logMessage, char *filterArg);
-int snoopy_filterregistry_getIndex     (char *filterName);
-int snoopy_filterregistry_isRegistered (char *filterName);
+int snoopy_filter_exclude_spawns_of (char *msg, char *arg);

--- a/src/filterregistry.c
+++ b/src/filterregistry.c
@@ -35,6 +35,7 @@
  * Two arrays holding data about filter functions
  */
 char *snoopy_filterregistry_names[] = {
+    "exclude_spawns_of",
     "exclude_uid",
     "only_root",
     "only_uid",
@@ -42,6 +43,7 @@ char *snoopy_filterregistry_names[] = {
 };
 
 int (*snoopy_filterregistry_ptrs []) (char *logMessage, char *arg) = {
+    snoopy_filter_exclude_spawns_of,
     snoopy_filter_exclude_uid,
     snoopy_filter_only_root,
     snoopy_filter_only_uid,


### PR DESCRIPTION
The exclude_spawns_of filter lets the user specify a "black list" of programs. Snoopy will not record the execution of processes descending from one of these programs.

This is useful to limit the noise generated by predictable programs such as cron.
