### PR TITLE
Add conflict rules to avoid installing both the snoopy and libsnoopy pkgs

### DIFF
--- a/contrib/debian/changelog
+++ b/contrib/debian/changelog
@@ -1,9 +1,10 @@
-snoopy (2:2.3.0rc1) UNRELEASED; urgency=medium
+snoopy (2:2.3.1rc1) UNRELEASED; urgency=medium
 
   * Bump version.
   * Change build options to enable filtering and config file.
+  * Add conflict rules to avoid installing both the snoopy and libsnoopy pkgs
 
- -- Fred Mora <fmora@datto.com>  Fri, 24 Apr 2015 18:27:42 -0400
+ -- Fred Mora <fmora@datto.com>  Tue, 28 Apr 2015 22:01:18 -0400
 
 snoopy (2:2.0.0rc5-1) unstable; urgency=low
 

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -10,6 +10,8 @@ Homepage: https://github.com/a2o/snoopy
 Package: libsnoopy
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Conflicts: snoopy
+Replaces: snoopy
 Description: execve() wrapper and logger
  snoopylogger is merely a shared library that is used as a wrapper
  to the execve() function provided by libc as to log every call


### PR DESCRIPTION

The snoopy package is available on the Ubuntu repos and should be replaced if libsnoopy is installed, especially if a new feature is configured in the snoopy.ini file.
