### PR TITLE
added parents option to not error if the directory already exists

### DIFF
--- a/contrib/rhel/snoopy.spec.in
+++ b/contrib/rhel/snoopy.spec.in
@@ -19,7 +19,7 @@ make %{?_smp_mflags}
 %install
 %make_install
 
-mkdir %{buildroot}/etc
+mkdir -p %{buildroot}/etc
 install -m 0644 etc/snoopy.ini %{buildroot}/%{_sysconfdir}/snoopy.ini
 
 %files


### PR DESCRIPTION
Trying to build centos rpms fails as %{buildroot}/etc already exists. Adding -p, --parents, changes the mkdir behavior to no error if existing