### PR TITLE
Improve parsing in exclude_spawns_of filter

### DIFF
--- a/src/filter/exclude_spawns_of.c
+++ b/src/filter/exclude_spawns_of.c
@@ -42,9 +42,16 @@
  * Local defines
  */
 #define   PROGLISTSEP               ','
-#define   ST_COMM_SIZE_MAX           32   // Keep these 3 in sync
-#define   ST_COMM_SCANF_PRECISION_S "31"  // Keep these 3 in sync
-#define   ST_COMM_LAST_CHAR_POS      31   // Keep these 3 in sync
+// Max bytes for command, including null
+#define   ST_COMM_SIZE_MAX           32
+// Max bytes needed from /proc/<pid>/stat, including null:
+// 20 digit PID, space, command in parens, space, 1 char state, space,
+// 20 digit PPID, null
+#define   ST_BUF_SIZE               (46 + ST_COMM_SIZE_MAX)
+// Min valid bytes from /proc/<pid>/stat, excluding null:
+// 1 digit PID, space, empty parens, space, 1 char state, space,
+// 1 digit PPID
+#define   ST_SIZE_MIN                 8
 
 
 
@@ -113,19 +120,21 @@ int find_ancestor_in_list(char **name_list)
     char stat_path[32]; // Path "/proc/nnnn/stat" where nnnn = some PID
     FILE *statf;
     int rc, found;
-    char *ancestor_name;
+    char *left, *right;
+    size_t len;
 
     /*
      * The following vars are read from /proc/PID/stat
      *
+     * st_buf:
+     * Buffer for PID, command, state, and PPID
      * st_comm:
-     * Buffer for exec file name. In kernel/include/linux/sched.h is this
+     * Buffer for command. In kernel/include/linux/sched.h this is
      * defined as 16 byte string, but let's keep a bit of spare room if
      * something suddenly changes in the kernel.
      */
-    char st_commBuff[ST_COMM_SIZE_MAX];
-    char *st_comm;
-    pid_t st_pid;
+    char st_buf[ST_BUF_SIZE];
+    char st_comm_buf[ST_COMM_SIZE_MAX];
     char st_state;
 
     if (name_list == NULL) {
@@ -140,33 +149,40 @@ int find_ancestor_in_list(char **name_list)
             return -1;
         }
 
-        // Grab the first few elements from the stat pseudo-file. Format from man 5 proc.
-        st_comm = st_commBuff;
-        rc = fscanf(statf, "%d %"ST_COMM_SCANF_PRECISION_S"s %c %d", &st_pid, st_comm, &st_state, &ppid);
-        if (rc == EOF) {
-            fclose(statf);
+        // Grab the first few elements from the stat pseudo-file
+        rc = fread(st_buf, 1, ST_BUF_SIZE - 1, statf);
+        st_buf[rc] = '\0';
+        fclose(statf);
+        if (rc < ST_SIZE_MIN) {
             return -1;
         }
-        /*
-         * Do not worry about %31s not being enough if command name in
-         * /proc/PID/stat exceeds it. fscanf() returns OK, it just shortens
-         * the resulting string to 31+\0.
-         */
 
-        // Secure string ending, just in case (this should be done by fscanf())
-        st_comm[ST_COMM_LAST_CHAR_POS] = '\0';
-
-        // stat provides st_comm as the name between parentheses. Get rid of the parens.
-        ancestor_name = st_comm + 1;
-        st_comm[strlen(st_comm) - 1] = '\0';
-        found = find_string_in_array(ancestor_name, name_list);
-
-        if (found) {
-            fclose(statf);
-            return 1;
+        // Find the first opening paren and the last closing paren
+        left = strchr(st_buf, '(');
+        right = strrchr(st_buf, ')');
+        if (left == NULL || right == NULL) {
+            return -1;
+        }
+        len = right - left - 1;
+        if (len <= 0 || len >= ST_COMM_SIZE_MAX) {
+            return -1;
         }
 
-        fclose(statf);
+        // Copy the command
+        memcpy(st_comm_buf, left + 1, len);
+        st_comm_buf[len] = '\0';
+
+        // Parse the PPID
+        rc = sscanf(right + 1, " %c %d", &st_state, &ppid);
+        if (rc != 2) {
+            return -1;
+        }
+
+        found = find_string_in_array(st_comm_buf, name_list);
+
+        if (found) {
+            return 1;
+        }
     }
 
     return 0; // Nothing found

--- a/tests/filter/Makefile.am
+++ b/tests/filter/Makefile.am
@@ -10,6 +10,15 @@ SCRIPT_PREFIX = filter
 TESTS  =
 XFAIL_TESTS  =
 
+if FILTER_ENABLED_exclude_spawns_of
+    TESTS += $(SCRIPT_PREFIX)_exclude_spawns_of-mustdrop-multiarg-first.sh
+    TESTS += $(SCRIPT_PREFIX)_exclude_spawns_of-mustdrop-multiarg-last.sh
+    TESTS += $(SCRIPT_PREFIX)_exclude_spawns_of-mustdrop-multiarg-mid.sh
+    TESTS += $(SCRIPT_PREFIX)_exclude_spawns_of-mustdrop-singlearg.sh
+    TESTS += $(SCRIPT_PREFIX)_exclude_spawns_of-mustlog-multiarg.sh
+    TESTS += $(SCRIPT_PREFIX)_exclude_spawns_of-mustlog-singlearg.sh
+endif
+
 if DATASOURCE_ENABLED_uid
 if FILTER_ENABLED_exclude_uid
     TESTS += $(SCRIPT_PREFIX)_exclude_uid-pass.sh

--- a/tests/filter/filter_exclude_spawns_of-mustdrop-multiarg-first.sh
+++ b/tests/filter/filter_exclude_spawns_of-mustdrop-multiarg-first.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+
+
+### Configure shell and bootstrap
+#
+set -e
+set -u
+. `dirname $BASH_SOURCE`/_bootstrap.sh
+
+
+
+### Get data
+#
+if ! $SNOOPY_TEST_FILTER   "msg"   "exclude_spawns_of"   "bash,aaaa,bbbb" > /dev/null; then
+    snoopy_testResult_pass
+else
+    snoopy_testResult_fail "Message passed through when it shouldn't."
+fi

--- a/tests/filter/filter_exclude_spawns_of-mustdrop-multiarg-last.sh
+++ b/tests/filter/filter_exclude_spawns_of-mustdrop-multiarg-last.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+
+
+### Configure shell and bootstrap
+#
+set -e
+set -u
+. `dirname $BASH_SOURCE`/_bootstrap.sh
+
+
+
+### Get data
+#
+if ! $SNOOPY_TEST_FILTER   "msg"   "exclude_spawns_of"   "aaaa,bbbb,bash" > /dev/null; then
+    snoopy_testResult_pass
+else
+    snoopy_testResult_fail "Message passed through when it shouldn't."
+fi

--- a/tests/filter/filter_exclude_spawns_of-mustdrop-multiarg-mid.sh
+++ b/tests/filter/filter_exclude_spawns_of-mustdrop-multiarg-mid.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+
+
+### Configure shell and bootstrap
+#
+set -e
+set -u
+. `dirname $BASH_SOURCE`/_bootstrap.sh
+
+
+
+### Get data
+#
+if ! $SNOOPY_TEST_FILTER   "msg"   "exclude_spawns_of"   "aaaa,bash,bbbb" > /dev/null; then
+    snoopy_testResult_pass
+else
+    snoopy_testResult_fail "Message passed through when it shouldn't."
+fi

--- a/tests/filter/filter_exclude_spawns_of-mustdrop-singlearg.sh
+++ b/tests/filter/filter_exclude_spawns_of-mustdrop-singlearg.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+
+
+### Configure shell and bootstrap
+#
+set -e
+set -u
+. `dirname $BASH_SOURCE`/_bootstrap.sh
+
+
+
+### Get data
+#
+if ! $SNOOPY_TEST_FILTER   "msg"   "exclude_spawns_of"   "bash" > /dev/null; then
+    snoopy_testResult_pass
+else
+    snoopy_testResult_fail "Message passed through when it shouldn't."
+fi

--- a/tests/filter/filter_exclude_spawns_of-mustlog-multiarg.sh
+++ b/tests/filter/filter_exclude_spawns_of-mustlog-multiarg.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+
+
+### Configure shell and bootstrap
+#
+set -e
+set -u
+. `dirname $BASH_SOURCE`/_bootstrap.sh
+
+
+
+### Get data
+#
+if $SNOOPY_TEST_FILTER   "msg"   "exclude_spawns_of"   "aaaa,bbbb,cccc" > /dev/null; then
+    snoopy_testResult_pass
+else
+    snoopy_testResult_fail "Message unexpectedly dropped."
+fi

--- a/tests/filter/filter_exclude_spawns_of-mustlog-singlearg.sh
+++ b/tests/filter/filter_exclude_spawns_of-mustlog-singlearg.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+
+
+### Configure shell and bootstrap
+#
+set -e
+set -u
+. `dirname $BASH_SOURCE`/_bootstrap.sh
+
+
+
+### Get data
+#
+if $SNOOPY_TEST_FILTER   "msg"   "exclude_spawns_of"   "aaaa" > /dev/null; then
+    snoopy_testResult_pass
+else
+    snoopy_testResult_fail "Message unexpectedly dropped."
+fi


### PR DESCRIPTION
Checklists for Pull requests
----------------------------

About pull request itself:
- [X] I am submitting a pull request:)
- [X] My submission does one logical thing only (one bugfix, one new feature). If I will want to supply multiple logical changes, I will submit multiple pull requests.
- [X] I have read and understood CONTRIBUTING guide @ https://github.com/a2o/snoopy/blob/master/.github/CONTRIBUTING.md

Code quality:
(not applicable for non-code fixes of course)
- [X] My submission is passing test suite run (./configure --enable-everything && make tests) - test suite reports zero unexpected failures.
- [X] My submission is passing Valgrind check (./configure --enable-everything --enable-dev-tools && make valgrind) - Valgrind reports "ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)".

Commits:
- [X] My commits are logical, easily readable, with concise comments.
- [X] My commits follow the KISS principle: do one thing, and do it well.

Licensing:
- [X] I am the author of submission or have been authorized by submission copyright holder to issue this pull request.

Branching:
- [X] My submission is based on master branch.
- [X] My submission is compatible with latest master branch updates (no conflicts, I did a rebase if it was necessary).
- [X] The name of the branch I want to merge upstream is not 'master' (except for only the most trivial fixes, like typos and such).
- [ ] My branch name is *feature/my-shiny-new-snoopy-feature-title* (for new features).
- [X] My branch name is *bugfix/my-totally-non-hackish-workaround* (for bugfixes).
- [ ] My branch name is *doc/what-i-did-to-documentation* (for documentation updates).

Continuous integration:
- [X] Once I will submit this pull request, I will wait for Travis-CI report (normally a couple of minutes) and fix any issues I might have introduced.



Pull request description
------------------------
This PR fixes issue #117 by parsing /proc/<pid>/stat more robustly. The technique is based on the one used by ps (see http://sources.debian.net/src/procps/2:3.3.9-9/proc/readproc.c/#L502), which accounts for the possibility of spaces and parens in command names.