### PR TITLE
Bugfix/rpname parsing

### DIFF
--- a/src/datasource/rpname.c
+++ b/src/datasource/rpname.c
@@ -127,17 +127,14 @@ char* read_proc_property (int pid, char* prop_name)
         /*
          * Separate line content into two tokens: key and value
          * If separation fails, continue to the next line ("Groups:" key is one such example)
-         *
-         * Explicitly initialized as pointer to "", otherwise coverity complains with
-         * "Uninitialized pointer read (UNINIT)".
          */
-        char *savePtr = "";
-        k = strtok_r(line, ":", &savePtr);
-        v = strtok_r(NULL, ":", &savePtr);
+        k = line;
+        v = strchr(line, ':');
         if (NULL == v) {
             continue;
         }
-
+        *v = '\0';
+        v++;
         /* The key we are looking for? */
         if (strcmp(prop_name, k) == 0) {
             /* Yes! */

--- a/tests/datasource/datasource_rpname.sh
+++ b/tests/datasource/datasource_rpname.sh
@@ -29,7 +29,7 @@ while [ "$NEW_PPID" != "1" ]; do
 done
 
 # Get root parent process name
-VAL_REAL=`cat /proc/$CUR_PID/status | grep '^Name:' | awk '{print $2}'`
+VAL_REAL=`cat /proc/$CUR_PID/status | grep '^Name:' | sed 's/^Name:\t//'`
 
 
 


### PR DESCRIPTION
Checklists for Pull requests
----------------------------

About pull request itself:
- [X] I am submitting a pull request:
- [X] My submission does one logical thing only (one bugfix, one new feature). If I will want to supply multiple logical changes, I will submit multiple pull requests.
- [X] I have read and understood CONTRIBUTING guide @ https://github.com/a2o/snoopy/blob/master/.github/CONTRIBUTING.md

Code quality:
(not applicable for non-code fixes of course)
- [X] My submission is passing test suite run (./configure --enable-everything && make tests) - test suite reports zero unexpected failures. Note: Since I use gcc7 I had to apply the patch from #122, otherwise snoopy doesn't compile at all.
- [X] My submission is passing Valgrind check (./configure --enable-everything --enable-dev-tools && make valgrind) - Valgrind reports "ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)".

Commits:
- [X] My commits are logical, easily readable, with concise comments.
- [X] My commits follow the KISS principle: do one thing, and do it well.

Licensing:
- [X] I am the author of submission or have been authorized by submission copyright holder to issue this pull request.

Branching:
- [X] My submission is based on master branch.
- [ ] My submission is compatible with latest master branch updates (no conflicts, I did a rebase if it was necessary).
- [X] The name of the branch I want to merge upstream is not 'master' (except for only the most trivial fixes, like typos and such).
- [ ] My branch name is *feature/my-shiny-new-snoopy-feature-title* (for new features).
- [X] My branch name is *bugfix/my-totally-non-hackish-workaround* (for bugfixes).
- [ ] My branch name is *doc/what-i-did-to-documentation* (for documentation updates).

Continuous integration:
- [X] Once I will submit this pull request, I will wait for Travis-CI report (normally a couple of minutes) and fix any issues I might have introduced.



Pull request description
------------------------
When running the testsuite from tmux, the `datasource_rpname.sh` test is unsuccessful and reports `Values do not match (snoopy="tmu", real="tmux:")`. The reason is that the tmux server process, which is the last parent before init, has an unusual process name:

    $ grep '^Name' status
    Name:	tmux: server

This contains both a colon and a space which triggers two distinct problems both fixed in this request:
-  The colon causes the read_proc_property function from rpname.c to stop at the colon (it then removes one additional character which would normally be a newline, so it ends up with "tmu").
- The space in the name causes `datasource_rpname.sh` to only extract the first part ("tmux:").