### PR TITLE
Change the content of snoopy.ini so it highlights requirement for proper file permissions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -108,7 +108,7 @@ Directory /doc/:
     src/filter/complex_filter_name.c;
 
 Directory /doc/internals/:
-- location of documetation useful to Snoopy developers and contributors;
+- location of documentation useful to Snoopy developers and contributors;
 - /doc/internals/README.md: main document about Snoopy internals
 
 
@@ -143,4 +143,4 @@ Pull requests:
 
 
 
-That is it. May the successfull-patch-submission-force be with you! :)
+That is it. May the successful-patch-submission-force be with you! :)

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -48,6 +48,14 @@ FILLIN
 
 
 
+## Steps to reproduce
+
+FILLIN - DO NOT SKIP THIS SECTION
+(Produce a guide for maintainers to reproduce your issue on their workstation.)
+(Using containers [LXC, Docker] is the best way to do it.)
+
+
+
 ## Expected result
 
 FILLIN
@@ -55,11 +63,5 @@ FILLIN
 
 
 ## Actual result
-
-FILLIN
-
-
-
-## Steps to reproduce
 
 FILLIN

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,23 +10,35 @@ I confirm that:
 
 ## Issue description - Environment basics
 
-(replace 'FILLIN' with actual values from your environment)
+    Guide:
+    - Remove this guide
+    - x86 is not supported anymore
+    - Replace 'FILLIN' with actual values from your environment
+    - Bug reports related to non-latest Snoopy releases will be closed as invalid.
+    - Using snoopy-install.sh enables Snoopy config file by default
+    - Threading support is not automatically enabled as of v2.4.4.
 
 | Key                                 | Value             | Comments                         |
 | ----------------------------------- | ----------------- | ---------------------------------|
-| Architecture:                       | x86_64            | x86 is not supported anymore     |
+| Architecture:                       | x86_64            | |
 | Linux distribution:                 | FILLIN            | |
 | Distribution version:               | FILLIN            | |
 | Snoopy version:                     | FILLIN            | |
-| Snoopy config file was used:        | FILLIN (yes|no)   | snoopy-install.sh enables this by default |
-| Snoopy threading support enabled:   | FILLIN (yes|no)   | not enabled by default as of v2.4.4       |
+| Snoopy config file was used:        | FILLIN (yes|no)   | |
+| Snoopy threading support enabled:   | FILLIN (yes|no)   | |
 
 
 
 ## Issue description - How was Snoopy installed
 
+    Guide:
+    - Remove this guide
+    - Describe installation method, was it:
+        - snoopy-install.sh?
+        - custom built (provide configure arguments)?
+        - distro package (is the version not supported anymore)?
+
 FILLIN
-(describe installation method - snoopy-install.sh, custom built (provide configure arguments), distro package)
 
 
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib/iniparser"]
-	path = lib/iniparser
-	url = https://github.com/a2o/iniparser.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,8 @@ env:
 script:
   - "./build/travis.sh $SNOOPY_TRAVIS_OPTS"
 
+after_failure:
+  - "./build/travis-show-debug-output.sh"
 
 addons:
   #

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,16 @@
 -------------------------------------------------------------------------------
 
 
+2016-08-014 - Version 2.4.6
+--------------------------
+o Bugfix (#106 @ GitHub): fix segmentation faults of Network Manager on
+    CentOS 7 when using DHCP address configuration.
+    (thanks tkimball83, p64 @ GitHub for reporting it, and jmtysonjr @ GitHub
+    for verifying the bugfix)
+o Internal: replace ini parsing library iniparser with inih
+    (triggered by #106 @ Github)
+
+
 2016-03-05 - Version 2.4.5
 --------------------------
 o Bugfix (#102 @ GitHub): fix broken validation of --with-syslog-facility

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,7 +3,7 @@
 -------------------------------------------------------------------------------
 
 
-2016-08-014 - Version 2.4.6
+2016-08-14 - Version 2.4.6
 --------------------------
 o Bugfix (#106 @ GitHub): fix segmentation faults of Network Manager on
     CentOS 7 when using DHCP address configuration.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Master:
 Stable:
 [![Build Status - Stable](https://travis-ci.org/a2o/snoopy.svg?branch=stable)](https://travis-ci.org/a2o/snoopy/branches)
 
+Chat:
+[![Join the chat at https://gitter.im/a2o/snoopy](https://badges.gitter.im/a2o/snoopy.svg)](https://gitter.im/a2o/snoopy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
 INFO: Snoopy is not a reliable auditing solution. Rogue users can easily manipulate
 environment to avoid logging by Snoopy. See [this FAQ entry](https://github.com/a2o/snoopy/blob/master/doc/FAQ.md#5-i-see-no-snoopy-output-after-initial-user-login).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Stable:
 [![Build Status - Stable](https://travis-ci.org/a2o/snoopy.svg?branch=stable)](https://travis-ci.org/a2o/snoopy/branches)
 
 INFO: Snoopy is not a reliable auditing solution. Rogue users can easily manipulate
-environment to avoid logging by Snoopy. See (this FAQ entry)[https://github.com/a2o/snoopy/blob/master/doc/FAQ.md#5-i-see-no-snoopy-output-after-initial-user-login].
+environment to avoid logging by Snoopy. See [this FAQ entry](https://github.com/a2o/snoopy/blob/master/doc/FAQ.md#5-i-see-no-snoopy-output-after-initial-user-login).
 
 
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ environment to avoid logging by Snoopy. See [this FAQ entry](https://github.com/
     * [Output](#output)
     * [Configuration](#configuration)
     * [Support](#support)
-      * [S.1 Keep all communication public](#s1-all-keep-communication-public)
+      * [S.1 Keep all communication public](#s1-keep-all-communication-public)
       * [S.2 Supported Snoopy versions](#s2-supported-snoopy-versions)
       * [S.3 Reporting bugs](#s3-reporting-bugs)
       * [S.4 Feature requests](#s4-feature-requests)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ environment to avoid logging by Snoopy. See [this FAQ entry](https://github.com/
 
 ## News
 
+2016-09-14:
+**Snoopy 2.4.6 released!**
+Maintenance release.
+
 2016-03-05:
 **Snoopy 2.4.5 released!**
 Maintenance release.
@@ -55,12 +59,6 @@ noise from non-tty processes considerably.
 **Snoopy 2.4.0 released!**
 Many changes, see the ChangeLog. Experimental thread safety added.
 All users are encouraged to upgrade to Snoopy version 2.4.0+ immediately.
-
-2015-05-12:
-**Snoopy 2.3.0 released!** This Snoopy version contains many
-improvements, bugfixes, new features and quite improved build process.
-All users are encouraged to upgrade to Snoopy version 2.3.0+ as soon
-as possible.
 
 
 
@@ -91,7 +89,7 @@ Detailed installation instructions are available here: [doc/INSTALL.md](doc/INST
 
 | Version                      | Download URI                                               |
 | ---------------------------- | ---------------------------------------------------------- |
-| Latest stable release        | http://source.a2o.si/download/snoopy/snoopy-2.4.5.tar.gz   |
+| Latest stable release        | http://source.a2o.si/download/snoopy/snoopy-2.4.6.tar.gz   |
 | Latest development release   | (N/A, clone this git repo, use master branch)              |
 | All releases                 | http://source.a2o.si/download/snoopy/                      |
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Snoopy Logger
 
 Snoopy is a tiny library that logs all executed commands (+ arguments) on your system.
-[![Flattr Snoopy Logger project](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=a2o&url=https://github.com/a2o/snoopy&title=Snoopy Logger)
+[![Flattr Snoopy Logger project](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=a2o&url=https://github.com/a2o/snoopy&title=Snoopy%20Logger)
 
 Master:
 [![Build Status - Master](https://travis-ci.org/a2o/snoopy.svg?branch=master)](https://travis-ci.org/a2o/snoopy/branches)

--- a/build/travis-show-debug-output.sh
+++ b/build/travis-show-debug-output.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+
+
+### Show everything from test suite
+#
+for FILE in `find tests -name '*.log' -or -name '*.trs' | sort`; do
+    echo
+    echo "FILE: $FILE"
+    cat $FILE
+done

--- a/config.h.in
+++ b/config.h.in
@@ -121,8 +121,7 @@
 /* Define to 1 if `vfork' works. */
 #undef HAVE_WORKING_VFORK
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
 #undef LT_OBJDIR
 
 /* Name of package */

--- a/configure.ac
+++ b/configure.ac
@@ -206,6 +206,8 @@ AC_CONFIG_FILES([Makefile
                  etc/Makefile
                  etc/snoopy.ini
                  lib/Makefile
+                 lib/inih/Makefile
+                 lib/inih/src/Makefile
                  src/Makefile
                  src/datasource/Makefile
                  src/eventsource/Makefile
@@ -812,23 +814,6 @@ dnl ============================================================================
 dnl ======= START: Check for config-dependent things ===========================
 dnl ============================================================================
 dnl ============================================================================
-
-
-### Config file - include lib/iniparser
-#
-# Also, configure it statically
-#
-AS_IF([test "x$configfile_enabled" == "xyes"], [
-    ac_configure_args_snoopy="$ac_configure_args"
-    ac_configure_args_lib_iniparser="--enable-subpackage --disable-documentation"
-    ac_configure_args="$ac_configure_args_lib_iniparser"
-
-    AC_CONFIG_COMMANDS_PRE([ac_configure_args="$ac_configure_args_snoopy"])
-    AC_CONFIG_COMMANDS_POST([ac_configure_args="$ac_configure_args_lib_iniparser"])
-    AC_CONFIG_SUBDIRS(lib/iniparser)
-
-    ac_configure_args="$ac_configure_args_snoopy"
-])
 
 
 ### Datasource snoopy_threads

--- a/configure.scan
+++ b/configure.scan
@@ -38,6 +38,8 @@ AC_CONFIG_FILES([Makefile
                  doc/internals/Makefile
                  etc/Makefile
                  lib/Makefile
+                 lib/inih/Makefile
+                 lib/inih/src/Makefile
                  src/Makefile
                  src/datasource/Makefile
                  src/eventsource/Makefile
@@ -53,5 +55,4 @@ AC_CONFIG_FILES([Makefile
                  tests/output/Makefile
                  tests/threads/Makefile
                  util/Makefile])
-AC_CONFIG_SUBDIRS([lib/iniparser])
 AC_OUTPUT

--- a/contrib/debian/README.Build.md
+++ b/contrib/debian/README.Build.md
@@ -32,7 +32,7 @@ Basically you need to run following commands:
     dpkg -i ../libsnoopy_2.0.0rc5-1_amd64.deb
 
 
-NOTES: Debian package versionning is tricky when working on git
+NOTES: Debian package versioning is tricky when working on git
 repositories. You can keep track on per-commit version number using `git
 describe --tags`.
 

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -32,6 +32,7 @@ Ubuntu 14.04 would be a good choice ATM, or RedHat/CentOS 7.
 Required versions of software:
 - automake 1.11
 - autoconf 2.69
+- libtool
 
 
 ### Older OSes

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -104,7 +104,7 @@ git submodule update
 - all data sources must build with -Wall -Werror -strict -std=c99 flags
     (enabled by default);
 - code indentation: 4 spaces, no tabs;
-- reserverd data source names:
+- reserved data source names:
     - snoopy*
 - IMPORTANT: Every data source must have corresponding test(s) in tests/datasource/
     directory, which enables automated testing for all upcoming changes. This

--- a/lib/inih/Makefile.am
+++ b/lib/inih/Makefile.am
@@ -1,11 +1,10 @@
 ### Include common Makefile configuration
 #
 include   $(top_srcdir)/build/Makefile.am.common
-SUBDIRS =
 
 
-### INI file parser
+
+### Subdir processing order
 #
-if CONFIGFILE_ENABLED
-SUBDIRS += inih
-endif
+SUBDIRS  =
+SUBDIRS += src

--- a/lib/inih/SOURCE.txt
+++ b/lib/inih/SOURCE.txt
@@ -1,0 +1,3 @@
+git-origin-url = 'https://github.com/benhoyt/inih.git'
+git-origin-ref = 'tags/r36-0-g5dbf5cb'
+patches-dir = 'patches/'

--- a/lib/inih/SOURCE.txt
+++ b/lib/inih/SOURCE.txt
@@ -1,3 +1,3 @@
 git-origin-url = 'https://github.com/benhoyt/inih.git'
-git-origin-ref = 'tags/r36-0-g5dbf5cb'
+git-origin-ref = 'tags/r42-0-g9d1af9d'
 patches-dir = 'patches/'

--- a/lib/inih/dev-update.sh
+++ b/lib/inih/dev-update.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+
+
+### Configure shell
+#
+set -e
+set -u
+GITORIGINURL="https://github.com/benhoyt/inih.git"
+GITORIGINREF="master"
+TMPGITDIR="./_tmp-inih-git"
+DESTDIR="."
+DESTDIRSRC="./src"
+
+
+
+### Clone the repo
+#
+rm -rf $TMPGITDIR
+git clone   $GITORIGINURL   $TMPGITDIR
+
+
+
+### Copy the files
+#
+cp $TMPGITDIR/ini.c $DESTDIRSRC
+cp $TMPGITDIR/ini.h $DESTDIRSRC
+
+
+
+### Apply patches
+#
+patch -p3 < ./patches/0001-strip-value-quotes.diff
+
+
+
+### Get the version information
+#
+INIH_VERSION=`cd $TMPGITDIR && git describe --all --long`
+cat << EOF > $DESTDIR/SOURCE.txt
+git-origin-url = '$GITORIGINURL'
+git-origin-ref = '$INIH_VERSION'
+patches-dir = 'patches/'
+EOF
+
+
+
+### Remove the tmp git dir
+#
+rm -rf $TMPGITDIR
+
+
+
+### All good.
+#
+echo "Any changes?"
+git status $DESTDIR
+
+echo
+echo "Update succeeded."

--- a/lib/inih/dev-update.sh
+++ b/lib/inih/dev-update.sh
@@ -7,10 +7,19 @@
 set -e
 set -u
 GITORIGINURL="https://github.com/benhoyt/inih.git"
-GITORIGINREF="master"
+GITREF="master"
 TMPGITDIR="./_tmp-inih-git"
 DESTDIR="."
 DESTDIRSRC="./src"
+
+
+
+### Parse arguments
+#
+if [ "${1:-}" != "" ]; then
+    GITREF="$1"
+fi
+echo "Using gitref: $GITREF"
 
 
 
@@ -18,6 +27,7 @@ DESTDIRSRC="./src"
 #
 rm -rf $TMPGITDIR
 git clone   $GITORIGINURL   $TMPGITDIR
+(cd $TMPGITDIR && git checkout $GITREF)
 
 
 
@@ -30,7 +40,7 @@ cp $TMPGITDIR/ini.h $DESTDIRSRC
 
 ### Apply patches
 #
-patch -p3 < ./patches/0001-strip-value-quotes.diff
+patch -p0 < ./patches/0001-strip-value-quotes.diff
 
 
 

--- a/lib/inih/patches/0001-strip-value-quotes.diff
+++ b/lib/inih/patches/0001-strip-value-quotes.diff
@@ -1,0 +1,22 @@
+diff --git a/lib/inih/src/ini.c b/lib/inih/src/ini.c
+index 27ca85b..2c015c8 100644
+--- a/lib/inih/src/ini.c
++++ b/lib/inih/src/ini.c
+@@ -149,6 +149,17 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
+ #endif
+                 rstrip(value);
+ 
++                /* Strip surrounding double and single quotes */
++                if ((*value == '"') && (value[strlen(value) - 1] == '"')) {
++                    value[strlen(value) - 1] = '\0';
++                    value += 1;
++                } else {
++                    if ((*value == '"') && (value[strlen(value) - 1] == '"')) {
++                        value[strlen(value) - 1] = '\0';
++                        value += 1;
++                    }
++                }
++
+                 /* Valid name[=:]value pair found, call handler */
+                 strncpy0(prev_name, name, sizeof(prev_name));
+                 if (!handler(user, section, name, value) && !error)

--- a/lib/inih/patches/0001-strip-value-quotes.diff
+++ b/lib/inih/patches/0001-strip-value-quotes.diff
@@ -1,9 +1,7 @@
-diff --git a/lib/inih/src/ini.c b/lib/inih/src/ini.c
-index 27ca85b..2c015c8 100644
---- a/lib/inih/src/ini.c
-+++ b/lib/inih/src/ini.c
-@@ -149,6 +149,17 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
- #endif
+--- src/ini.c.orig	2018-12-26 21:08:15.289767000 +0000
++++ src/ini.c	2018-12-26 21:07:25.707778000 +0000
+@@ -187,6 +187,17 @@
+                 value = lskip(value);
                  rstrip(value);
  
 +                /* Strip surrounding double and single quotes */
@@ -19,4 +17,4 @@ index 27ca85b..2c015c8 100644
 +
                  /* Valid name[=:]value pair found, call handler */
                  strncpy0(prev_name, name, sizeof(prev_name));
-                 if (!handler(user, section, name, value) && !error)
+                 if (!HANDLER(user, section, name, value) && !error)

--- a/lib/inih/src/Makefile.am
+++ b/lib/inih/src/Makefile.am
@@ -1,0 +1,14 @@
+### Include common Makefile configuration
+#
+include   $(top_srcdir)/build/Makefile.am.common
+
+
+
+### Create library "libinih"
+#
+noinst_LTLIBRARIES = \
+    libinih.la
+
+libinih_la_SOURCES = \
+    ini.c \
+    ini.h

--- a/lib/inih/src/ini.c
+++ b/lib/inih/src/ini.c
@@ -1,0 +1,205 @@
+/* inih -- simple .INI file parser
+
+inih is released under the New BSD license (see LICENSE.txt). Go to the project
+home page for more info:
+
+https://github.com/benhoyt/inih
+
+*/
+
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+
+#include "ini.h"
+
+#if !INI_USE_STACK
+#include <stdlib.h>
+#endif
+
+#define MAX_SECTION 50
+#define MAX_NAME 50
+
+/* Strip whitespace chars off end of given string, in place. Return s. */
+static char* rstrip(char* s)
+{
+    char* p = s + strlen(s);
+    while (p > s && isspace((unsigned char)(*--p)))
+        *p = '\0';
+    return s;
+}
+
+/* Return pointer to first non-whitespace char in given string. */
+static char* lskip(const char* s)
+{
+    while (*s && isspace((unsigned char)(*s)))
+        s++;
+    return (char*)s;
+}
+
+/* Return pointer to first char (of chars) or inline comment in given string,
+   or pointer to null at end of string if neither found. Inline comment must
+   be prefixed by a whitespace character to register as a comment. */
+static char* find_chars_or_comment(const char* s, const char* chars)
+{
+#if INI_ALLOW_INLINE_COMMENTS
+    int was_space = 0;
+    while (*s && (!chars || !strchr(chars, *s)) &&
+           !(was_space && strchr(INI_INLINE_COMMENT_PREFIXES, *s))) {
+        was_space = isspace((unsigned char)(*s));
+        s++;
+    }
+#else
+    while (*s && (!chars || !strchr(chars, *s))) {
+        s++;
+    }
+#endif
+    return (char*)s;
+}
+
+/* Version of strncpy that ensures dest (size bytes) is null-terminated. */
+static char* strncpy0(char* dest, const char* src, size_t size)
+{
+    strncpy(dest, src, size);
+    dest[size - 1] = '\0';
+    return dest;
+}
+
+/* See documentation in header file. */
+int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
+                     void* user)
+{
+    /* Uses a fair bit of stack (use heap instead if you need to) */
+#if INI_USE_STACK
+    char line[INI_MAX_LINE];
+#else
+    char* line;
+#endif
+    char section[MAX_SECTION] = "";
+    char prev_name[MAX_NAME] = "";
+
+    char* start;
+    char* end;
+    char* name;
+    char* value;
+    int lineno = 0;
+    int error = 0;
+
+#if !INI_USE_STACK
+    line = (char*)malloc(INI_MAX_LINE);
+    if (!line) {
+        return -2;
+    }
+#endif
+
+    /* Scan through stream line by line */
+    while (reader(line, INI_MAX_LINE, stream) != NULL) {
+        lineno++;
+
+        start = line;
+#if INI_ALLOW_BOM
+        if (lineno == 1 && (unsigned char)start[0] == 0xEF &&
+                           (unsigned char)start[1] == 0xBB &&
+                           (unsigned char)start[2] == 0xBF) {
+            start += 3;
+        }
+#endif
+        start = lskip(rstrip(start));
+
+        if (*start == ';' || *start == '#') {
+            /* Per Python configparser, allow both ; and # comments at the
+               start of a line */
+        }
+#if INI_ALLOW_MULTILINE
+        else if (*prev_name && *start && start > line) {
+            /* Non-blank line with leading whitespace, treat as continuation
+               of previous name's value (as per Python configparser). */
+            if (!handler(user, section, prev_name, start) && !error)
+                error = lineno;
+        }
+#endif
+        else if (*start == '[') {
+            /* A "[section]" line */
+            end = find_chars_or_comment(start + 1, "]");
+            if (*end == ']') {
+                *end = '\0';
+                strncpy0(section, start + 1, sizeof(section));
+                *prev_name = '\0';
+            }
+            else if (!error) {
+                /* No ']' found on section line */
+                error = lineno;
+            }
+        }
+        else if (*start) {
+            /* Not a comment, must be a name[=:]value pair */
+            end = find_chars_or_comment(start, "=:");
+            if (*end == '=' || *end == ':') {
+                *end = '\0';
+                name = rstrip(start);
+                value = lskip(end + 1);
+#if INI_ALLOW_INLINE_COMMENTS
+                end = find_chars_or_comment(value, NULL);
+                if (*end)
+                    *end = '\0';
+#endif
+                rstrip(value);
+
+                /* Strip surrounding double and single quotes */
+                if ((*value == '"') && (value[strlen(value) - 1] == '"')) {
+                    value[strlen(value) - 1] = '\0';
+                    value += 1;
+                } else {
+                    if ((*value == '\'') && (value[strlen(value) - 1] == '\'')) {
+                        value[strlen(value) - 1] = '\0';
+                        value += 1;
+                    }
+                }
+
+                /* Valid name[=:]value pair found, call handler */
+                strncpy0(prev_name, name, sizeof(prev_name));
+                if (!handler(user, section, name, value) && !error)
+                    error = lineno;
+            }
+            else if (!error) {
+                /* No '=' or ':' found on name[=:]value line */
+                error = lineno;
+            }
+        }
+
+#if INI_STOP_ON_FIRST_ERROR
+        if (error)
+            break;
+#endif
+    }
+
+#if !INI_USE_STACK
+    free(line);
+#endif
+
+    return error;
+}
+
+/* See documentation in header file. */
+int ini_parse_file(FILE* file, ini_handler handler, void* user)
+{
+    return ini_parse_stream((ini_reader)fgets, file, handler, user);
+}
+
+/* See documentation in header file. */
+int ini_parse(const char* filename, ini_handler handler, void* user)
+{
+    FILE* file;
+    int error;
+
+    file = fopen(filename, "r");
+    if (!file)
+        return -1;
+    error = ini_parse_file(file, handler, user);
+    fclose(file);
+    return error;
+}

--- a/lib/inih/src/ini.c
+++ b/lib/inih/src/ini.c
@@ -24,6 +24,12 @@ https://github.com/benhoyt/inih
 #define MAX_SECTION 50
 #define MAX_NAME 50
 
+/* Used by ini_parse_string() to keep track of string parsing state. */
+typedef struct {
+    const char* ptr;
+    size_t num_left;
+} ini_parse_string_ctx;
+
 /* Strip whitespace chars off end of given string, in place. Return s. */
 static char* rstrip(char* s)
 {
@@ -64,7 +70,7 @@ static char* find_chars_or_comment(const char* s, const char* chars)
 /* Version of strncpy that ensures dest (size bytes) is null-terminated. */
 static char* strncpy0(char* dest, const char* src, size_t size)
 {
-    strncpy(dest, src, size);
+    strncpy(dest, src, size - 1);
     dest[size - 1] = '\0';
     return dest;
 }
@@ -76,8 +82,14 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
     /* Uses a fair bit of stack (use heap instead if you need to) */
 #if INI_USE_STACK
     char line[INI_MAX_LINE];
+    int max_line = INI_MAX_LINE;
 #else
     char* line;
+    int max_line = INI_INITIAL_ALLOC;
+#endif
+#if INI_ALLOW_REALLOC
+    char* new_line;
+    int offset;
 #endif
     char section[MAX_SECTION] = "";
     char prev_name[MAX_NAME] = "";
@@ -90,14 +102,40 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
     int error = 0;
 
 #if !INI_USE_STACK
-    line = (char*)malloc(INI_MAX_LINE);
+    line = (char*)malloc(INI_INITIAL_ALLOC);
     if (!line) {
         return -2;
     }
 #endif
 
+#if INI_HANDLER_LINENO
+#define HANDLER(u, s, n, v) handler(u, s, n, v, lineno)
+#else
+#define HANDLER(u, s, n, v) handler(u, s, n, v)
+#endif
+
     /* Scan through stream line by line */
-    while (reader(line, INI_MAX_LINE, stream) != NULL) {
+    while (reader(line, max_line, stream) != NULL) {
+#if INI_ALLOW_REALLOC
+        offset = strlen(line);
+        while (offset == max_line - 1 && line[offset - 1] != '\n') {
+            max_line *= 2;
+            if (max_line > INI_MAX_LINE)
+                max_line = INI_MAX_LINE;
+            new_line = realloc(line, max_line);
+            if (!new_line) {
+                free(line);
+                return -2;
+            }
+            line = new_line;
+            if (reader(line + offset, max_line - offset, stream) == NULL)
+                break;
+            if (max_line >= INI_MAX_LINE)
+                break;
+            offset += strlen(line + offset);
+        }
+#endif
+
         lineno++;
 
         start = line;
@@ -110,15 +148,14 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
 #endif
         start = lskip(rstrip(start));
 
-        if (*start == ';' || *start == '#') {
-            /* Per Python configparser, allow both ; and # comments at the
-               start of a line */
+        if (strchr(INI_START_COMMENT_PREFIXES, *start)) {
+            /* Start-of-line comment */
         }
 #if INI_ALLOW_MULTILINE
         else if (*prev_name && *start && start > line) {
             /* Non-blank line with leading whitespace, treat as continuation
                of previous name's value (as per Python configparser). */
-            if (!handler(user, section, prev_name, start) && !error)
+            if (!HANDLER(user, section, prev_name, start) && !error)
                 error = lineno;
         }
 #endif
@@ -141,12 +178,13 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
             if (*end == '=' || *end == ':') {
                 *end = '\0';
                 name = rstrip(start);
-                value = lskip(end + 1);
+                value = end + 1;
 #if INI_ALLOW_INLINE_COMMENTS
                 end = find_chars_or_comment(value, NULL);
                 if (*end)
                     *end = '\0';
 #endif
+                value = lskip(value);
                 rstrip(value);
 
                 /* Strip surrounding double and single quotes */
@@ -154,7 +192,7 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
                     value[strlen(value) - 1] = '\0';
                     value += 1;
                 } else {
-                    if ((*value == '\'') && (value[strlen(value) - 1] == '\'')) {
+                    if ((*value == '"') && (value[strlen(value) - 1] == '"')) {
                         value[strlen(value) - 1] = '\0';
                         value += 1;
                     }
@@ -162,7 +200,7 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
 
                 /* Valid name[=:]value pair found, call handler */
                 strncpy0(prev_name, name, sizeof(prev_name));
-                if (!handler(user, section, name, value) && !error)
+                if (!HANDLER(user, section, name, value) && !error)
                     error = lineno;
             }
             else if (!error) {
@@ -202,4 +240,41 @@ int ini_parse(const char* filename, ini_handler handler, void* user)
     error = ini_parse_file(file, handler, user);
     fclose(file);
     return error;
+}
+
+/* An ini_reader function to read the next line from a string buffer. This
+   is the fgets() equivalent used by ini_parse_string(). */
+static char* ini_reader_string(char* str, int num, void* stream) {
+    ini_parse_string_ctx* ctx = (ini_parse_string_ctx*)stream;
+    const char* ctx_ptr = ctx->ptr;
+    size_t ctx_num_left = ctx->num_left;
+    char* strp = str;
+    char c;
+
+    if (ctx_num_left == 0 || num < 2)
+        return NULL;
+
+    while (num > 1 && ctx_num_left != 0) {
+        c = *ctx_ptr++;
+        ctx_num_left--;
+        *strp++ = c;
+        if (c == '\n')
+            break;
+        num--;
+    }
+
+    *strp = '\0';
+    ctx->ptr = ctx_ptr;
+    ctx->num_left = ctx_num_left;
+    return str;
+}
+
+/* See documentation in header file. */
+int ini_parse_string(const char* string, ini_handler handler, void* user) {
+    ini_parse_string_ctx ctx;
+
+    ctx.ptr = string;
+    ctx.num_left = strlen(string);
+    return ini_parse_stream((ini_reader)ini_reader_string, &ctx, handler,
+                            user);
 }

--- a/lib/inih/src/ini.h
+++ b/lib/inih/src/ini.h
@@ -1,0 +1,93 @@
+/* inih -- simple .INI file parser
+
+inih is released under the New BSD license (see LICENSE.txt). Go to the project
+home page for more info:
+
+https://github.com/benhoyt/inih
+
+*/
+
+#ifndef __INI_H__
+#define __INI_H__
+
+/* Make this header file easier to include in C++ code */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+
+/* Typedef for prototype of handler function. */
+typedef int (*ini_handler)(void* user, const char* section,
+                           const char* name, const char* value);
+
+/* Typedef for prototype of fgets-style reader function. */
+typedef char* (*ini_reader)(char* str, int num, void* stream);
+
+/* Parse given INI-style file. May have [section]s, name=value pairs
+   (whitespace stripped), and comments starting with ';' (semicolon). Section
+   is "" if name=value pair parsed before any section heading. name:value
+   pairs are also supported as a concession to Python's configparser.
+
+   For each name=value pair parsed, call handler function with given user
+   pointer as well as section, name, and value (data only valid for duration
+   of handler call). Handler should return nonzero on success, zero on error.
+
+   Returns 0 on success, line number of first error on parse error (doesn't
+   stop on first error), -1 on file open error, or -2 on memory allocation
+   error (only when INI_USE_STACK is zero).
+*/
+int ini_parse(const char* filename, ini_handler handler, void* user);
+
+/* Same as ini_parse(), but takes a FILE* instead of filename. This doesn't
+   close the file when it's finished -- the caller must do that. */
+int ini_parse_file(FILE* file, ini_handler handler, void* user);
+
+/* Same as ini_parse(), but takes an ini_reader function pointer instead of
+   filename. Used for implementing custom or string-based I/O. */
+int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
+                     void* user);
+
+/* Nonzero to allow multi-line value parsing, in the style of Python's
+   configparser. If allowed, ini_parse() will call the handler with the same
+   name for each subsequent line parsed. */
+#ifndef INI_ALLOW_MULTILINE
+#define INI_ALLOW_MULTILINE 1
+#endif
+
+/* Nonzero to allow a UTF-8 BOM sequence (0xEF 0xBB 0xBF) at the start of
+   the file. See http://code.google.com/p/inih/issues/detail?id=21 */
+#ifndef INI_ALLOW_BOM
+#define INI_ALLOW_BOM 1
+#endif
+
+/* Nonzero to allow inline comments (with valid inline comment characters
+   specified by INI_INLINE_COMMENT_PREFIXES). Set to 0 to turn off and match
+   Python 3.2+ configparser behaviour. */
+#ifndef INI_ALLOW_INLINE_COMMENTS
+#define INI_ALLOW_INLINE_COMMENTS 1
+#endif
+#ifndef INI_INLINE_COMMENT_PREFIXES
+#define INI_INLINE_COMMENT_PREFIXES ";"
+#endif
+
+/* Nonzero to use stack, zero to use heap (malloc/free). */
+#ifndef INI_USE_STACK
+#define INI_USE_STACK 1
+#endif
+
+/* Stop parsing on first error (default is to keep parsing). */
+#ifndef INI_STOP_ON_FIRST_ERROR
+#define INI_STOP_ON_FIRST_ERROR 0
+#endif
+
+/* Maximum line length for any line in INI file. */
+#ifndef INI_MAX_LINE
+#define INI_MAX_LINE 200
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __INI_H__ */

--- a/lib/inih/src/ini.h
+++ b/lib/inih/src/ini.h
@@ -83,7 +83,7 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
 
 /* Maximum line length for any line in INI file. */
 #ifndef INI_MAX_LINE
-#define INI_MAX_LINE 200
+#define INI_MAX_LINE 512
 #endif
 
 #ifdef __cplusplus

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -57,7 +57,7 @@ libsnoopy_no_execve_la_SOURCES += \
 	configfile.c \
 	configfile.h
 libsnoopy_no_execve_la_LIBADD += \
-	../lib/iniparser/src/libiniparser.la
+	../lib/inih/src/libinih.la
 endif
 
 # If config file is enabled, build and link these too

--- a/src/configfile.h
+++ b/src/configfile.h
@@ -26,9 +26,16 @@
  * Functions to load/parse config file
  */
 int   snoopy_configfile_load (char *iniFilePath);
+int   snoopy_configfile_parser_callback (
+    void* sth,
+    const char* section,
+    const char* name,
+    const char* confValString
+);
 void  snoopy_configfile_parse_output               (const char *confVal);
 void  snoopy_configfile_parse_syslog_facility      (const char *confVal);
 void  snoopy_configfile_parse_syslog_level         (const char *confVal);
 char *snoopy_configfile_syslog_value_cleanup       (char *confVal);
 char *snoopy_configfile_syslog_value_remove_prefix (char *confVal);
 void  snoopy_configfile_strtoupper (char *s);
+int   snoopy_configfile_getboolean (const char *c, int notfound);

--- a/src/datasource/cmdline.c
+++ b/src/datasource/cmdline.c
@@ -68,7 +68,7 @@ int snoopy_datasource_cmdline (char * const result, char const * const arg)
     snoopy_inputdatastorage = snoopy_inputdatastorage_get();
 
     /* Count number of arguments */
-    for (cmdLineArgCount=0 ; *(snoopy_inputdatastorage->argv+cmdLineArgCount) != '\0' ; cmdLineArgCount++);
+    for (cmdLineArgCount=0 ; *(snoopy_inputdatastorage->argv+cmdLineArgCount) != 0 ; cmdLineArgCount++);
 
     /* Calculate memory requirement for cmdLine */
     cmdLineSizeSum = 0;

--- a/src/datasource/rpname.c
+++ b/src/datasource/rpname.c
@@ -152,7 +152,7 @@ char* read_proc_property (int pid, char* prop_name)
                 strncpy(returnValue, v, PROC_PID_STATUS_VAL_MAX_LENGTH);
                 returnValue[PROC_PID_STATUS_VAL_MAX_LENGTH_STR-1] = 0; // Change newline into null character
             } else {
-                strncpy(returnValue, v, PROC_PID_STATUS_VAL_MAX_LENGTH_STR);
+                strncpy(returnValue, v, PROC_PID_STATUS_VAL_MAX_LENGTH_STR-1);
             }
 
             // Do a cleanup and return a string duplicate, which should be freed by the caller

--- a/src/datasource/rpname.c
+++ b/src/datasource/rpname.c
@@ -48,7 +48,8 @@
  * Local defines
  */
 #define PID_ROOT                1
-#define PID_EMPTY               0
+#define PID_ZERO                0 // In containers, if attached from the host
+#define PID_UNKNOWN             -1
 
 #define PROC_PID_STATUS_KEY_NAME        "Name"
 #define PROC_PID_STATUS_KEY_PPID        "PPid"
@@ -190,7 +191,7 @@ int get_parent_pid (int pid)
         return ppid_int;
     }
 
-    return PID_EMPTY;
+    return PID_UNKNOWN;
 }
 
 
@@ -203,7 +204,7 @@ int get_rpname (int pid, char *result)
     size_t  nameLen;
 
     parentPid = get_parent_pid(pid);
-    if (PID_ROOT == parentPid) {
+    if ((PID_ROOT == parentPid) || (PID_ZERO == parentPid)) {
         name = read_proc_property(pid, PROC_PID_STATUS_KEY_NAME);
         if (NULL != name) {
             nameLen = snprintf(result, SNOOPY_DATASOURCE_MESSAGE_MAX_SIZE, "%s", name);
@@ -212,7 +213,7 @@ int get_rpname (int pid, char *result)
             nameLen = snprintf(result, SNOOPY_DATASOURCE_MESSAGE_MAX_SIZE, "%s", UNKNOWN_STR);
         }
         return nameLen;
-    } else if (PID_EMPTY == parentPid) {
+    } else if (PID_UNKNOWN == parentPid) {
         return snprintf(result, SNOOPY_DATASOURCE_MESSAGE_MAX_SIZE, "%s", UNKNOWN_STR);
     } else {
         return get_rpname(parentPid, result);

--- a/src/datasource/rpname.c
+++ b/src/datasource/rpname.c
@@ -127,17 +127,14 @@ char* read_proc_property (int pid, char* prop_name)
         /*
          * Separate line content into two tokens: key and value
          * If separation fails, continue to the next line ("Groups:" key is one such example)
-         *
-         * Explicitly initialized as pointer to "", otherwise coverity complains with
-         * "Uninitialized pointer read (UNINIT)".
          */
-        char *savePtr = "";
-        k = strtok_r(line, ":", &savePtr);
-        v = strtok_r(NULL, ":", &savePtr);
+        k = line;
+        v = strchr(line, ':');
         if (NULL == v) {
             continue;
         }
-
+        *v = '\0';
+        v++;
         /* The key we are looking for? */
         if (strcmp(prop_name, k) == 0) {
             /* Yes! */

--- a/src/datasource/tty.c
+++ b/src/datasource/tty.c
@@ -65,7 +65,7 @@ int snoopy_datasource_tty (char * const result, char const * const arg)
         if (ENOTTY == retVal) {
             return snprintf(result, SNOOPY_DATASOURCE_MESSAGE_MAX_SIZE, "(none)");
         }
-        return snprintf(result, SNOOPY_DATASOURCE_MESSAGE_MAX_SIZE, "ERROR(ttyname_r->EUNKNOWN)");
+        return snprintf(result, SNOOPY_DATASOURCE_MESSAGE_MAX_SIZE, "(unknown)");
     }
 
     return snprintf(result, SNOOPY_DATASOURCE_MESSAGE_MAX_SIZE, "%s", ttyPath);

--- a/src/datasource/tty_uid.c
+++ b/src/datasource/tty_uid.c
@@ -72,7 +72,7 @@ int snoopy_datasource_tty_uid (char * const result, char const * const arg)
         if (ENOTTY == retVal) {
             return snprintf(result, SNOOPY_DATASOURCE_MESSAGE_MAX_SIZE, "(none)");
         }
-        return snprintf(result, SNOOPY_DATASOURCE_MESSAGE_MAX_SIZE, "ERROR(ttyname_r->EUNKNOWN)");
+        return snprintf(result, SNOOPY_DATASOURCE_MESSAGE_MAX_SIZE, "(unknown)");
     }
 
     /* Get owner of tty */

--- a/src/datasource/tty_username.c
+++ b/src/datasource/tty_username.c
@@ -82,7 +82,7 @@ int snoopy_datasource_tty_username (char * const result, char const * const arg)
         if (ENOTTY == retVal) {
             return snprintf(result, SNOOPY_DATASOURCE_MESSAGE_MAX_SIZE, "(none)");
         }
-        return snprintf(result, SNOOPY_DATASOURCE_MESSAGE_MAX_SIZE, "ERROR(ttyname_r->EUNKNOWN)");
+        return snprintf(result, SNOOPY_DATASOURCE_MESSAGE_MAX_SIZE, "(unknown)");
     }
 
 

--- a/src/filtering.c
+++ b/src/filtering.c
@@ -59,7 +59,6 @@ int snoopy_filtering_check_chain (
     char *filterChain
 ) {
     char  filterChainCopy[SNOOPY_FILTER_CHAIN_MAX_SIZE];   // Must be here, or strtok_r segfaults
-    int   filterChainCopySize;
     int   j;
     char *str;
     char *rest;
@@ -67,12 +66,8 @@ int snoopy_filtering_check_chain (
     char *fcPos_filterSpecArg;   // Pointer to argument part of single filter specification in a filter chain
 
     // Copy the filter chain specification to separate string, to be used in strtok_r
-    filterChainCopySize = strlen(filterChain);
-    if (filterChainCopySize > SNOOPY_FILTER_CHAIN_MAX_SIZE - 1) {
-        filterChainCopySize = SNOOPY_FILTER_CHAIN_MAX_SIZE - 1;
-    }
-    strncpy(filterChainCopy, filterChain, filterChainCopySize);
-    filterChainCopy[filterChainCopySize] = '\0';
+    strncpy(filterChainCopy, filterChain, SNOOPY_FILTER_CHAIN_MAX_SIZE - 1);
+    filterChainCopy[SNOOPY_FILTER_CHAIN_MAX_SIZE-1] = '\0';
 
     // Loop through all filters
     for (j=1, str=filterChainCopy;  ; j++, str=NULL) {

--- a/tests/datasource/datasource_rpname.sh
+++ b/tests/datasource/datasource_rpname.sh
@@ -29,7 +29,7 @@ while [ "$NEW_PPID" != "1" ]; do
 done
 
 # Get root parent process name
-VAL_REAL=`cat /proc/$CUR_PID/status | grep '^Name:' | awk '{print $2}'`
+VAL_REAL=`cat /proc/$CUR_PID/status | grep '^Name:' | sed 's/^Name:\t//'`
 
 
 

--- a/tests/datasource/datasource_rpname.sh
+++ b/tests/datasource/datasource_rpname.sh
@@ -18,7 +18,10 @@ VAL_SNOOPY=`$SNOOPY_TEST_DATASOURCE rpname`
 CUR_PID=$$
 NEW_PPID=`snoopy_test_getValue_fromPs "$CUR_PID" "ppid"`
 I=0
-while [ "$NEW_PPID" != "1" ]; do
+# Stop at:
+# - PID 1: init
+# - PID 0: appears in container when attached to it from the host
+while [[ "$NEW_PPID" != "1" ]] && [[ "$NEW_PPID" != "0" ]]; do
     I=`expr $I + 1`
     if [ "$I" -gt "100" ]; then
         snoopy_testResult_fail "Endless loop".

--- a/tests/datasource/datasource_tty.sh
+++ b/tests/datasource/datasource_tty.sh
@@ -13,6 +13,10 @@ set -u
 ### Get data
 #
 VAL_SNOOPY=`$SNOOPY_TEST_DATASOURCE tty`
+if [ "(unknown)" == "$VAL_SNOOPY" ]; then
+    VAL_SNOOPY="(none)"
+fi
+
 if ! tty -s; then
     VAL_REAL="(none)"
 else

--- a/tests/datasource/datasource_tty.sh
+++ b/tests/datasource/datasource_tty.sh
@@ -17,6 +17,9 @@ if ! tty -s; then
     VAL_REAL="(none)"
 else
     VAL_REAL=`tty`
+    if [ "not a tty" == "$VAL_REAL" ]; then
+        VAL_REAL="(none)"
+    fi
 fi
 
 

--- a/tests/datasource/datasource_tty_uid.sh
+++ b/tests/datasource/datasource_tty_uid.sh
@@ -16,7 +16,12 @@ VAL_SNOOPY=`$SNOOPY_TEST_DATASOURCE tty_uid`
 if ! tty -s; then
     VAL_REAL="(none)"
 else
-    VAL_REAL=`tty | xargs ls -lan | awk '{print $3}'`
+    VAL_REAL=`tty`
+    if [ "not a tty" == "$VAL_REAL" ]; then
+        VAL_REAL="(none)"
+    else
+        VAL_REAL=`echo "$VAL_REAL" | xargs ls -lan | awk '{print $3}'`
+    fi
 fi
 
 

--- a/tests/datasource/datasource_tty_uid.sh
+++ b/tests/datasource/datasource_tty_uid.sh
@@ -13,6 +13,10 @@ set -u
 ### Get data
 #
 VAL_SNOOPY=`$SNOOPY_TEST_DATASOURCE tty_uid`
+if [ "(unknown)" == "$VAL_SNOOPY" ]; then
+    VAL_SNOOPY="(none)"
+fi
+
 if ! tty -s; then
     VAL_REAL="(none)"
 else

--- a/tests/datasource/datasource_tty_username.sh
+++ b/tests/datasource/datasource_tty_username.sh
@@ -16,7 +16,12 @@ VAL_SNOOPY=`$SNOOPY_TEST_DATASOURCE tty_username`
 if ! tty -s; then
     VAL_REAL="(none)"
 else
-    VAL_REAL=`tty | xargs ls -la | awk '{print $3}'`
+    VAL_REAL=`tty`
+    if [ "not a tty" == "$VAL_REAL" ]; then
+        VAL_REAL="(none)"
+    else
+        VAL_REAL=`echo "$VAL_REAL" | xargs ls -la | awk '{print $3}'`
+    fi
 fi
 
 

--- a/tests/datasource/datasource_tty_username.sh
+++ b/tests/datasource/datasource_tty_username.sh
@@ -13,6 +13,10 @@ set -u
 ### Get data
 #
 VAL_SNOOPY=`$SNOOPY_TEST_DATASOURCE tty_username`
+if [ "(unknown)" == "$VAL_SNOOPY" ]; then
+    VAL_SNOOPY="(none)"
+fi
+
 if ! tty -s; then
     VAL_REAL="(none)"
 else

--- a/tests/output/output_socket.sh
+++ b/tests/output/output_socket.sh
@@ -25,14 +25,17 @@ touch $FILE_OUT
 socat UNIX-LISTEN:$FILE_SOCKET OPEN:$FILE_OUT &
 SOCAT_PID=$!
 
-# Sleep a bit, if socket file, or sometimes this fails as socket is not yet present
-if [ ! -e $FILE_SOCKET ]; then
-    sleep 0.2
-elif [ ! -S $FILE_SOCKET ]; then
-    sleep 0.5
-elif [ ! -S $FILE_SOCKET ]; then
-    sleep 2
-fi
+# Wait for the socket file to appear
+i=0
+while [ ! -e $FILE_SOCKET ]; do
+    i=`expr $i + 1`
+    snoopy_testRun_info "Waiting for socket ($i)..."
+    sleep 0.1
+
+    if [ "$i" -gt "100" ]; then
+        snoopy_testResult_fail "Socat listening socket $FILE_SOCKET did not appear."
+    fi
+done
 
 # Send content to this socket
 echo "$VAL_REAL" | socat - UNIX-CONNECT:$FILE_SOCKET


### PR DESCRIPTION
Replace following lines 

```
; Example:
;output = console
;output = devlog
;output = file:/var/log/snoopy.log
;output = socket:/var/run/socket-for-snoopy.sock
```
with 
```
; Example:
;output = console
;output = devlog
;output = file:/var/log/snoopy.log ; NOTICE: Needs appropriate file permissions for all users that are to be snoopied. Using "root:root:0666" will only allow logging root's commands.
;output = socket:/var/run/socket-for-snoopy.sock
```
Actual change in the 4th line.