### PR TITLE
Fix datasource_login test to more consistenly use `logname`

### DIFF
--- a/tests/datasource/datasource_login.sh
+++ b/tests/datasource/datasource_login.sh
@@ -14,7 +14,7 @@ set -u
 #
 VAL_SNOOPY=`$SNOOPY_TEST_DATASOURCE login`
 
-if ! tty -s; then
+if ! logname 2>/dev/null; then
     VAL_REAL=""
 else
     VAL_REAL=`logname`


### PR DESCRIPTION
Checklists for Pull requests
----------------------------

About pull request itself:
- [X] I am submitting a pull request:)
- [X] My submission does one logical thing only (one bugfix, one new feature). If I will want to supply multiple logical changes, I will submit multiple pull requests.
- [X] I have read and understood CONTRIBUTING guide @ https://github.com/a2o/snoopy/blob/master/.github/CONTRIBUTING.md

Code quality:
(not applicable for non-code fixes of course)
- [X] My submission is passing test suite run (./configure --enable-everything && make tests) - test suite reports zero unexpected failures.
- [X] My submission is passing Valgrind check (./configure --enable-everything --enable-dev-tools && make valgrind) - Valgrind reports "ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)".

Commits:
- [X] My commits are logical, easily readable, with concise comments.
- [X] My commits follow the KISS principle: do one thing, and do it well.

Licensing:
- [X] I am the author of submission or have been authorized by submission copyright holder to issue this pull request.

Branching:
- [X] My submission is based on master branch.
- [X] My submission is compatible with latest master branch updates (no conflicts, I did a rebase if it was necessary).
- [X] The name of the branch I want to merge upstream is not 'master' (except for only the most trivial fixes, like typos and such).
- [ ] My branch name is *feature/my-shiny-new-snoopy-feature-title* (for new features).
- [X] My branch name is *bugfix/my-totally-non-hackish-workaround* (for bugfixes).
- [ ] My branch name is *doc/what-i-did-to-documentation* (for documentation updates).

Continuous integration:
- [X] Once I will submit this pull request, I will wait for Travis-CI report (normally a couple of minutes) and fix any issues I might have introduced.



Pull request description
------------------------

Playing with snoopy in a dev docker container I hit an error with the "datasource_login" test beause whilst `tty` returned a valid tty, no login name existed for `logname` to return.

This PR just makes it so that if the test considers `logname` to be the source of truth, it does so consistently rather than assuming a correlation with `tty`, increasing the stability of tests in containers with unusual login/tty properties.
