### PR TITLE
GH-160 double quotes in default message

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,14 @@
 -------------------------------------------------------------------------------
 
 
+202x-xx-xx - Version 2.4.x
+--------------------------
+o Bugfix (GH #160 & #163):
+    Allow double quotes and backslashes in message format defined
+    via `./configure --with-message-format="..."`
+    (Thanks to Pascal Trouvin (@ptrouvin @ GH) for the inital PR.)
+
+
 2020-11-13 - Version 2.4.9
 --------------------------
 o Bugfix (#161 @ GitHub):

--- a/configure.ac
+++ b/configure.ac
@@ -428,8 +428,7 @@ AC_ARG_WITH(message-format,
     ],
     [with_message_format="@<:@uid:%{uid} sid:%{sid} tty:%{tty} cwd:%{cwd} filename:%{filename}@:>@: %{cmdline}"]
 )
-#AC_DEFINE_UNQUOTED(SNOOPY_CONF_MESSAGE_FORMAT, "$with_message_format", [Custom message format to use])
-AC_DEFINE_UNQUOTED(SNOOPY_CONF_MESSAGE_FORMAT, "$(echo $with_message_format | sed 's/"/\\"/g')", [Custom message format to use])
+AC_DEFINE_UNQUOTED(SNOOPY_CONF_MESSAGE_FORMAT, "$(echo $with_message_format | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')", [Custom message format to use])
 AC_SUBST([SNOOPY_CONF_MESSAGE_FORMAT], [$with_message_format])
 AC_MSG_NOTICE([Snoopy default message format: "$with_message_format"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -428,7 +428,8 @@ AC_ARG_WITH(message-format,
     ],
     [with_message_format="@<:@uid:%{uid} sid:%{sid} tty:%{tty} cwd:%{cwd} filename:%{filename}@:>@: %{cmdline}"]
 )
-AC_DEFINE_UNQUOTED(SNOOPY_CONF_MESSAGE_FORMAT, "$with_message_format", [Custom message format to use])
+#AC_DEFINE_UNQUOTED(SNOOPY_CONF_MESSAGE_FORMAT, "$with_message_format", [Custom message format to use])
+AC_DEFINE_UNQUOTED(SNOOPY_CONF_MESSAGE_FORMAT, "$(echo $with_message_format | sed 's/"/\\"/g')", [Custom message format to use])
 AC_SUBST([SNOOPY_CONF_MESSAGE_FORMAT], [$with_message_format])
 AC_MSG_NOTICE([Snoopy default message format: "$with_message_format"])
 


### PR DESCRIPTION
This PR is a substitute for #160:
- It cherry-picks usable commit from #160 
- Additionally, it expands the scope to allow backslashes to be specified on the `./configure --with-message-format="X"` line as well.