### PR TITLE
GH #113: Store ./configure command used during the build and make it accessible via a new data source

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,10 @@
 
 202x-xx-xx - Version 2.4.x
 --------------------------
+o Enhancement (GH #113 & #164):
+    Store the ./configure command used to build the Snoopy and provide access
+    to the data via the snoopy_configure_command data source.
+
 o Bugfix (GH #160 & #163):
     Allow double quotes and backslashes in message format defined
     via `./configure --with-message-format="..."`

--- a/config.h.in
+++ b/config.h.in
@@ -152,6 +152,9 @@
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 
+/* Configure command that was used to build Snoopy */
+#undef SNOOPY_CONFIGURE_COMMAND
+
 /* Is config file parsing enabled? */
 #undef SNOOPY_CONF_CONFIGFILE_ENABLED
 
@@ -214,6 +217,9 @@
 
 /* Is datasource "sid" available? */
 #undef SNOOPY_CONF_DATASOURCE_ENABLED_sid
+
+/* Is datasource "snoopy_configure_command" available? Forced "Yes". */
+#undef SNOOPY_CONF_DATASOURCE_ENABLED_snoopy_configure_command
 
 /* Is datasource "snoopy_literal" available? */
 #undef SNOOPY_CONF_DATASOURCE_ENABLED_snoopy_literal

--- a/configure.ac
+++ b/configure.ac
@@ -258,6 +258,13 @@ AC_MSG_NOTICE([=================================================================
 
 
 
+dnl ============================================================================
+dnl ======= START section: DATASOURCES & MESSAGE FORMAT ========================
+dnl ============================================================================
+AC_DEFINE_UNQUOTED(SNOOPY_CONFIGURE_COMMAND, "./configure $(echo $ac_configure_args | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')", [Configure command that was used to build Snoopy])
+AC_MSG_NOTICE([Snoopy build configuration command: ./configure $ac_configure_args])
+AC_MSG_NOTICE([-])
+
 
 
 # ============================================================================
@@ -390,6 +397,7 @@ SNOOPY_CONFIGURE_DATASOURCE_ENABLE( [pid],            [PID of process performing
 SNOOPY_CONFIGURE_DATASOURCE_ENABLE( [ppid],           [parent PID of process performing the execution])
 SNOOPY_CONFIGURE_DATASOURCE_ENABLE( [rpname],         [real parent name found up the process tree])
 SNOOPY_CONFIGURE_DATASOURCE_ENABLE( [sid],            [session leader PID])
+SNOOPY_CONFIGURE_DATASOURCE_FORCE(  [snoopy_configure_command], [returns the ./configure command that was used to build Snoopy])
 SNOOPY_CONFIGURE_DATASOURCE_ENABLE( [snoopy_literal], [dummy data source - only returns what it receives as argument])
 SNOOPY_CONFIGURE_DATASOURCE_ENABLE( [snoopy_threads], [number of threads that Snoopy currently is initialized for])
 SNOOPY_CONFIGURE_DATASOURCE_FORCE(  [snoopy_version], [installed Snoopy version])

--- a/etc/snoopy.ini.in
+++ b/etc/snoopy.ini.in
@@ -32,6 +32,7 @@
 ; - %{ppid}           ; (available=@enable_datasource_ppid@) Parent process ID of process that executed the command
 ; - %{rpname}         ; (available=@enable_datasource_rpname@) Root process name of process that executed the command
 ; - %{sid}            ; (available=@enable_datasource_sid@) Process id of session group process leader
+; - %{snoopy_configure_command} ; (available=@enable_datasource_snoopy_configure_command@) The ./configure command that was used to build Snoopy
 ; - %{snoopy_threads} ; (available=@enable_datasource_snoopy_threads@) Number of threads that Snoopy currently is configured for
 ; - %{snoopy_version} ; (available=@enable_datasource_snoopy_version@) Snoopy version
 ; - %{snoopy_literal:arg} ; (available=@enable_datasource_snoopy_literal@) Dummy data source, only returns its argument literally

--- a/src/datasource/Makefile.am
+++ b/src/datasource/Makefile.am
@@ -179,6 +179,14 @@ libsnoopy_datasources_all_la_SOURCES += \
 	sid.h
 endif
 
+# Data source: snoopy_configure_command
+#
+if DATASOURCE_ENABLED_snoopy_configure_command
+libsnoopy_datasources_all_la_SOURCES += \
+	snoopy_configure_command.c \
+	snoopy_configure_command.h
+endif
+
 # Data source: snoopy_literal
 #
 if DATASOURCE_ENABLED_snoopy_literal

--- a/src/datasource/snoopy_configure_command.c
+++ b/src/datasource/snoopy_configure_command.c
@@ -1,0 +1,57 @@
+/*
+ * SNOOPY LOGGER
+ *
+ * File: snoopy/datasource/snoopy_configure_command.c
+ *
+ * Copyright (c) 2014-2015 Bostjan Skufca <bostjan@a2o.si>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+
+
+/* 
+ * Includes order: from local to global
+ */
+#include "snoopy_configure_command.h"
+
+#include "snoopy.h"
+
+#ifndef   _XOPEN_SOURCE   /* Needed to get getpgid and getsid on older glibc */
+#define   _XOPEN_SOURCE   500
+#endif
+#include <stdio.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+
+
+/*
+ * SNOOPY DATA SOURCE: snoopy_configure_command
+ *
+ * Description:
+ *     Dummy data source that returns the configure command that was used to build Snoopy.
+ *
+ * Params:
+ *     result: pointer to string, to write result into
+ *     arg:    (ignored)
+ *
+ * Return:
+ *     number of characters in the returned string, or SNOOPY_DATASOURCE_FAILURE
+ */
+int snoopy_datasource_snoopy_configure_command (char * const result, char const * const arg)
+{
+    return snprintf(result, SNOOPY_DATASOURCE_MESSAGE_MAX_SIZE, "%s", SNOOPY_CONFIGURE_COMMAND);
+}

--- a/src/datasource/snoopy_configure_command.h
+++ b/src/datasource/snoopy_configure_command.h
@@ -1,0 +1,28 @@
+/*
+ * SNOOPY LOGGER
+ *
+ * File: snoopy/datasource/snoopy_configure_command.h
+ *
+ * Copyright (c) 2014-2015 Bostjan Skufca <bostjan@a2o.si>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+
+
+/*
+ * SNOOPY DATA SOURCE: snoopy_configure_command
+ */
+int snoopy_datasource_snoopy_configure_command (char * const result, char const * const arg);

--- a/src/datasourceregistry.c
+++ b/src/datasourceregistry.c
@@ -94,6 +94,9 @@
 #ifdef SNOOPY_CONF_DATASOURCE_ENABLED_sid
 #include "datasource/sid.h"
 #endif
+#ifdef SNOOPY_CONF_DATASOURCE_ENABLED_snoopy_configure_command
+#include "datasource/snoopy_configure_command.h"
+#endif
 #ifdef SNOOPY_CONF_DATASOURCE_ENABLED_snoopy_literal
 #include "datasource/snoopy_literal.h"
 #endif
@@ -202,6 +205,9 @@ char* snoopy_datasourceregistry_names[] = {
 #ifdef SNOOPY_CONF_DATASOURCE_ENABLED_sid
     "sid",
 #endif
+#ifdef SNOOPY_CONF_DATASOURCE_ENABLED_snoopy_configure_command
+    "snoopy_configure_command",
+#endif
 #ifdef SNOOPY_CONF_DATASOURCE_ENABLED_snoopy_literal
     "snoopy_literal",
 #endif
@@ -306,6 +312,9 @@ int (*snoopy_datasourceregistry_ptrs []) (char * const result, char const * cons
 #endif
 #ifdef SNOOPY_CONF_DATASOURCE_ENABLED_sid
     snoopy_datasource_sid,
+#endif
+#ifdef SNOOPY_CONF_DATASOURCE_ENABLED_snoopy_configure_command
+    snoopy_datasource_snoopy_configure_command,
 #endif
 #ifdef SNOOPY_CONF_DATASOURCE_ENABLED_snoopy_literal
     snoopy_datasource_snoopy_literal,

--- a/tests/datasource/Makefile.am
+++ b/tests/datasource/Makefile.am
@@ -86,6 +86,10 @@ if DATASOURCE_ENABLED_sid
     TESTS += $(SCRIPT_PREFIX)_sid.sh
 endif
 
+if DATASOURCE_ENABLED_snoopy_configure_command
+    TESTS += $(SCRIPT_PREFIX)_snoopy_configure_command.sh
+endif
+
 if DATASOURCE_ENABLED_snoopy_literal
     TESTS += $(SCRIPT_PREFIX)_snoopy_literal.sh
 endif

--- a/tests/datasource/datasource_snoopy_configure_command.sh
+++ b/tests/datasource/datasource_snoopy_configure_command.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+
+
+### Configure shell and bootstrap
+#
+set -e
+set -u
+. `dirname $BASH_SOURCE`/_bootstrap.sh
+
+
+
+### Get data
+#
+VAL_SNOOPY=`$SNOOPY_TEST_DATASOURCE snoopy_configure_command`
+
+
+
+### Evaluate
+#
+if [[ $VAL_SNOOPY =~ \./configure ]]; then
+    snoopy_testResult_pass
+else
+    snoopy_testResult_fail "The output does not start with './configure'. Instead, we got this: $VAL_SNOOPY"
+fi


### PR DESCRIPTION
Implements #113.