### PR TITLE
Enable thread safety by default

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,14 @@
 
 
 
+202x-xx-xx - Version 2.5.0
+--------------------------
+o Change/Enhancement (GH #166):
+    Enable thread safety by default. It can still be disabled at build time
+    via the --disable-thread-safety flag.
+
+
+
 2021-10-17 - Version 2.4.15
 ---------------------------
 o Bugfix (GH #201):
@@ -65,7 +73,6 @@ o Bugfix (GH #184):
 o Bugfix (GH #174):
     Fix invalid memory access that could only be encountered by running a
     test suite. Regular Snoopy operation was unaffected by this.
-
 
 
 2020-11-30 - Version 2.4.10

--- a/configure.ac
+++ b/configure.ac
@@ -334,11 +334,11 @@ dnl ======= ENABLE THREAD SAFETY ===============================================
 dnl ============================================================================
 AC_ARG_ENABLE(thread-safety,
     [AS_HELP_STRING(
-        [--enable-thread-safety],
-        [EXPERIMENTAL: enable parts of code that ensure safe multi-threaded operation [default=disabled]]
+        [--disable-thread-safety],
+        [Disable parts of code that ensure safe multi-threaded operation [default=enabled]]
     )],
     SNOOPY_CONFIGURE_ENABLE_GENERIC_SPECIFIED(  [thread_safety], [thread_safety_enabled], [$enableval], []),
-    SNOOPY_CONFIGURE_ENABLE_GENERIC_UNSPECIFIED([thread_safety], [thread_safety_enabled], [$enable_everything], [no])
+    SNOOPY_CONFIGURE_ENABLE_GENERIC_UNSPECIFIED([thread_safety], [thread_safety_enabled], [$enable_everything], [yes])
 )
 SNOOPY_CONFIGURE_ENABLE_GENERIC_EVALUATE([$thread_safety_enabled], [THREAD_SAFETY_ENABLED], [thread safety])
 


### PR DESCRIPTION
There have been a few reports of odd segmentation fault issues
circulating around the internet such as this one:
https://bugs.launchpad.net/ubuntu/+source/snoopy/+bug/1698090

Let's enable thread safety (which has already solved a few occurences
of similar issues) and make these a thing of a past (or resolve the actual
issue once threading-related errors are out of the picture).
