### PR TITLE
GH #119: Fix symbol leaks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -98,6 +98,7 @@ AC_PROG_LIBTOOL
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
 AC_PROG_MKDIR_P
+AC_PROG_NM
 AC_PROG_SED
 
 
@@ -208,6 +209,7 @@ AC_CONFIG_FILES([Makefile
                  tests/configfile/Makefile
                  tests/datasource/Makefile
                  tests/filter/Makefile
+                 tests/general/Makefile
                  tests/message/Makefile
                  tests/output/Makefile
                  tests/threads/Makefile

--- a/configure.scan
+++ b/configure.scan
@@ -49,6 +49,7 @@ AC_CONFIG_FILES([Makefile
                  tests/configfile/Makefile
                  tests/datasource/Makefile
                  tests/filter/Makefile
+                 tests/general/Makefile
                  tests/message/Makefile
                  tests/output/Makefile
                  tests/threads/Makefile

--- a/lib/inih/patches/0002-prefix-function-names.diff
+++ b/lib/inih/patches/0002-prefix-function-names.diff
@@ -1,0 +1,16 @@
+--- src/ini.h.ORIG	2020-11-26 03:37:52.533640594 +0100
++++ src/ini.h	2020-11-26 03:38:43.553738846 +0100
+@@ -10,6 +10,13 @@
+ #ifndef __INI_H__
+ #define __INI_H__
+ 
++/* START For Snoopy - redefine function names, to avoid symbol name collisions */
++#define ini_parse          snoopy_ini_parse
++#define ini_parse_file     snoopy_ini_parse_file
++#define ini_parse_stream   snoopy_ini_parse_stream
++#define ini_parse_string   snoopy_ini_parse_string
++/* END For Snoopy */
++
+ /* Make this header file easier to include in C++ code */
+ #ifdef __cplusplus
+ extern "C" {

--- a/lib/inih/src/ini.h
+++ b/lib/inih/src/ini.h
@@ -10,6 +10,13 @@ https://github.com/benhoyt/inih
 #ifndef __INI_H__
 #define __INI_H__
 
+/* START For Snoopy - redefine function names, to avoid symbol name collisions */
+#define ini_parse          snoopy_ini_parse
+#define ini_parse_file     snoopy_ini_parse_file
+#define ini_parse_stream   snoopy_ini_parse_stream
+#define ini_parse_string   snoopy_ini_parse_string
+/* END For Snoopy */
+
 /* Make this header file easier to include in C++ code */
 #ifdef __cplusplus
 extern "C" {

--- a/lib/liblcthw/patches/0004-prefix-function-names.diff
+++ b/lib/liblcthw/patches/0004-prefix-function-names.diff
@@ -1,0 +1,21 @@
+--- src/list.h.ORIG	2020-11-26 03:40:34.773954562 +0100
++++ src/list.h	2020-11-26 03:41:02.702009021 +0100
+@@ -1,6 +1,18 @@
+ #ifndef lcthw_List_h
+ #define lcthw_List_h
+ 
++/* START For Snoopy - redefine function names, to avoid symbol name collisions */
++#define List_clear           snoopy_List_clear
++#define List_clear_destroy   snoopy_List_clear_destroy
++#define List_create          snoopy_List_create
++#define List_destroy         snoopy_List_destroy
++#define List_pop             snoopy_List_pop
++#define List_push            snoopy_List_push
++#define List_remove          snoopy_List_remove
++#define List_shift           snoopy_List_shift
++#define List_unshift         snoopy_List_unshift
++/* END For Snoopy */
++
+ #include <stdlib.h>
+ 
+ struct ListNode;

--- a/lib/liblcthw/src/list.h
+++ b/lib/liblcthw/src/list.h
@@ -1,6 +1,18 @@
 #ifndef lcthw_List_h
 #define lcthw_List_h
 
+/* START For Snoopy - redefine function names, to avoid symbol name collisions */
+#define List_clear           snoopy_List_clear
+#define List_clear_destroy   snoopy_List_clear_destroy
+#define List_create          snoopy_List_create
+#define List_destroy         snoopy_List_destroy
+#define List_pop             snoopy_List_pop
+#define List_push            snoopy_List_push
+#define List_remove          snoopy_List_remove
+#define List_shift           snoopy_List_shift
+#define List_unshift         snoopy_List_unshift
+/* END For Snoopy */
+
 #include <stdlib.h>
 
 struct ListNode;

--- a/src/datasource/rpname.c
+++ b/src/datasource/rpname.c
@@ -64,9 +64,9 @@
 /*
  * Non-public function prototypes
  */
-int   get_parent_pid (int pid);
-int   get_rpname (int pid, char *result);
-char* read_proc_property (int pid, char* prop_name);
+static int   get_parent_pid (int pid);
+static int   get_rpname (int pid, char *result);
+static char* read_proc_property (int pid, char* prop_name);
 
 
 
@@ -91,7 +91,7 @@ int snoopy_datasource_rpname (char * const result, char const * const arg)
 
 
 /* Read /proc/{pid}/status file and extract the property */
-char* read_proc_property (int pid, char* prop_name)
+static char* read_proc_property (int pid, char* prop_name)
 {
     char    pid_file[50];
     FILE   *fp;
@@ -179,7 +179,7 @@ char* read_proc_property (int pid, char* prop_name)
 
 
 /* Get parent pid */
-int get_parent_pid (int pid)
+static int get_parent_pid (int pid)
 {
     char *ppid_str;
     int   ppid_int;
@@ -197,7 +197,7 @@ int get_parent_pid (int pid)
 
 
 /* Find root process name */
-int get_rpname (int pid, char *result)
+static int get_rpname (int pid, char *result)
 {
     int     parentPid;
     char   *name;

--- a/src/filter/exclude_spawns_of.c
+++ b/src/filter/exclude_spawns_of.c
@@ -51,9 +51,9 @@
 /*
  * Non-public function prototypes
  */
-int find_ancestor_in_list(char **name_list);
-int find_string_in_array(char *str, char **str_array);
-char **string_to_token_array(char *str);
+static int find_ancestor_in_list(char **name_list);
+static int find_string_in_array(char *str, char **str_array);
+static char **string_to_token_array(char *str);
 
 
 
@@ -107,7 +107,7 @@ int snoopy_filter_exclude_spawns_of(char *msg, char const * const arg)
  *    0 if there are no ancestor that have a name found in name_list
  *   -1 if error.
  */
-int find_ancestor_in_list(char **name_list)
+static int find_ancestor_in_list(char **name_list)
 {
     pid_t ppid;
     char stat_path[32]; // Path "/proc/nnnn/stat" where nnnn = some PID
@@ -182,7 +182,7 @@ int find_ancestor_in_list(char **name_list)
  *    1 if str matches one of the strings in str_array
  *    0 if there are no matches or if either argument is NULL.
  */
-int find_string_in_array(char *str, char **str_array)
+static int find_string_in_array(char *str, char **str_array)
 {
     if ((str == NULL) || (str_array == NULL)) {
         return 0;
@@ -210,7 +210,7 @@ int find_string_in_array(char *str, char **str_array)
  *    If str is NULL or empty, or if error, returns NULL.
  */
 
-char **string_to_token_array(char *str)
+static char **string_to_token_array(char *str)
 {
     char *p;
     int i;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -16,6 +16,7 @@ SUBDIRS     += datasource
 if FILTERING_ENABLED
     SUBDIRS += filter
 endif
+SUBDIRS     += general
 SUBDIRS     += message
 SUBDIRS     += output
 if THREAD_SAFETY_ENABLED

--- a/tests/general/Makefile.am
+++ b/tests/general/Makefile.am
@@ -1,0 +1,28 @@
+### Include common Makefile configuration
+#
+include   $(top_srcdir)/build/Makefile.am.common
+
+
+
+### Which tests to run
+#
+SCRIPT_PREFIX = general
+TESTS         =
+XFAIL_TESTS   =
+
+TESTS        += $(SCRIPT_PREFIX)-symbol-leaks.sh
+
+
+
+### Include tests in distribution archive
+#
+EXTRA_DIST    = _bootstrap.sh
+EXTRA_DIST   += $(TESTS)
+
+
+
+### Remove stale temporary test files, if tests got stuck
+#
+clean-local:
+	rm -f *.ini ;
+	rm -f *.out ;

--- a/tests/general/_bootstrap.sh
+++ b/tests/general/_bootstrap.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+
+
+### Configure shell
+#
+set -e
+set -u
+
+
+
+### Include main _bootstrap.sh
+#
+. `dirname $BASH_SOURCE`/../_bootstrap.sh

--- a/tests/general/general-symbol-leaks.sh
+++ b/tests/general/general-symbol-leaks.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+
+
+### Configure shell and bootstrap
+#
+set -e
+set -u
+. `dirname $BASH_SOURCE`/_bootstrap.sh
+
+
+
+### Check for leaked global symbols
+#
+RES=`nm $SNOOPY_LIBSNOOPY_TEST_SO_PATH | grep ' T ' | grep -v ' snoopy_' | grep -Ev ' execve?$' | grep -c . | cat`
+if [ "$RES" != "0" ]; then
+    nm $SNOOPY_LIBSNOOPY_TEST_SO_PATH | grep ' T ' | grep -v ' snoopy_' | grep -Ev ' execve?$' | cat
+    snoopy_testResult_fail "The .so library is leaking global symbols that are not prefixed with 'snoopy_' prefix. Inspect with 'nm $SNOOPY_LIBSNOOPY_TEST_SO_PATH' manually."
+else
+    snoopy_testResult_pass "No leaked symbols found."
+fi


### PR DESCRIPTION
Fixes #119.

Symbols that were defined by the external ini parsing library (namely `ini_parse()` function) is interfering with PHP's function of the same name. Weirdly enough, the issue only happens when PHP is running under Apache (as mod_php), and not in the standalone more.

The solution is to stop the symbol leak, and use `snoopy_` prefix  for all the symbols that the library makes available.

There are a few places where symbols are leaking and need fixing:
- `lib/inih/`
- `lib/liblcthw/`
- `src/datasource/rpname.c`
- `src/filter/exclude_spawns_of.c`

Lastly, create a test that will always check the library for leaked symbols.