### PR TITLE
GH #117: Add tests for exclude_spawns_of that verify if parent processes with spaces in their name are correctly detected

### DIFF
--- a/tests/bin/Makefile.am
+++ b/tests/bin/Makefile.am
@@ -46,6 +46,19 @@ snoopy_test_threads_SOURCES         = snoopy-test-threads.c
 snoopy_test_threads_LDADD           = $(top_builddir)/src/libsnoopy-debug-addons.la
 endif
 
+noinst_PROGRAMS                    += spaceparent
+spaceparent_SOURCES                 = spaceparent.c
+
+
+
+### Create a program called "space parent", for testing filter exclude_spawns_of
+#
+all-local:
+	cp spaceparent "space parent"
+
+clean-local:
+	rm "space parent"
+
 
 
 ### Create test library, whole

--- a/tests/bin/spaceparent.c
+++ b/tests/bin/spaceparent.c
@@ -1,0 +1,53 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h> /* for fork */
+#include <sys/types.h> /* for pid_t */
+#include <sys/wait.h> /* for wait */
+
+int main (int argc, char **argv)
+{
+    if (argc < 2) {
+        printf("Pass command to run as an argument: \"./space parent\" /cmd/to/run [args]\n");
+        exit(1);
+    }
+
+    // Copy the argv
+    char** new_argv = malloc((argc) * sizeof *new_argv);
+    for (int i=1; i < argc; ++i)
+    {
+        size_t length = strlen(argv[i])+1;
+        new_argv[i-1] = malloc(length);
+        memcpy(new_argv[i-1], argv[i], length);
+    }
+    new_argv[argc-1] = NULL;
+
+    /* Spawn a child to run the program. */
+    pid_t pid = fork();
+    if (pid == -1) { /* fork failed */
+        printf("fork() failed\n");
+        exit(2);
+    }
+
+    if (pid == 0) { /* child process */
+        //static char *argv[] = {
+        //    "echo",
+        //    "Foo is my name.",
+        //    NULL
+        //};
+        //execv("/bin/echo", argv);
+        execv(argv[1], new_argv);
+
+        /* This only gets executed if execv fails */
+        printf("execv() failed\n");
+        exit(3);
+
+    } else { /* pid!=0; parent process */
+        int status;
+        waitpid(pid, &status, 0); /* wait for child to exit */
+        if (status != 0) {
+            printf("Child regurned with a non-zero status: %d\n", status);
+            exit(4);
+        }
+    }
+}

--- a/tests/filter/Makefile.am
+++ b/tests/filter/Makefile.am
@@ -15,8 +15,10 @@ if FILTER_ENABLED_exclude_spawns_of
     TESTS += $(SCRIPT_PREFIX)_exclude_spawns_of-mustdrop-multiarg-last.sh
     TESTS += $(SCRIPT_PREFIX)_exclude_spawns_of-mustdrop-multiarg-mid.sh
     TESTS += $(SCRIPT_PREFIX)_exclude_spawns_of-mustdrop-singlearg.sh
+    TESTS += $(SCRIPT_PREFIX)_exclude_spawns_of-mustdrop-spaceparent.sh
     TESTS += $(SCRIPT_PREFIX)_exclude_spawns_of-mustlog-multiarg.sh
     TESTS += $(SCRIPT_PREFIX)_exclude_spawns_of-mustlog-singlearg.sh
+    TESTS += $(SCRIPT_PREFIX)_exclude_spawns_of-mustlog-spaceparent.sh
 endif
 
 if DATASOURCE_ENABLED_uid

--- a/tests/filter/filter_exclude_spawns_of-mustdrop-spaceparent.sh
+++ b/tests/filter/filter_exclude_spawns_of-mustdrop-spaceparent.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+
+
+### Configure shell and bootstrap
+#
+set -e
+set -u
+. `dirname $BASH_SOURCE`/_bootstrap.sh
+
+
+
+### Get data
+#
+if ! "$SNOOPY_TESTS_BINDIR/space parent" $SNOOPY_TEST_FILTER   "msg"   "exclude_spawns_of"   "space parent"; then
+    snoopy_testResult_pass
+else
+    snoopy_testResult_fail "Message passed through when it shouldn't."
+fi

--- a/tests/filter/filter_exclude_spawns_of-mustlog-spaceparent.sh
+++ b/tests/filter/filter_exclude_spawns_of-mustlog-spaceparent.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+
+
+### Configure shell and bootstrap
+#
+set -e
+set -u
+. `dirname $BASH_SOURCE`/_bootstrap.sh
+
+
+
+### Get data
+#
+if "$SNOOPY_TESTS_BINDIR/space parent" $SNOOPY_TEST_FILTER   "msg"   "exclude_spawns_of"   "parachuteparent"; then
+    snoopy_testResult_pass
+else
+    snoopy_testResult_fail "Message passed through when it shouldn't."
+fi


### PR DESCRIPTION
Related to #117 and #118.