### PR TITLE
GH #145: Enable analysis of PID 1 in filter `exclude_spawns_of`

### DIFF
--- a/src/filter/exclude_spawns_of.c
+++ b/src/filter/exclude_spawns_of.c
@@ -141,7 +141,7 @@ static int find_ancestor_in_list(char **name_list)
         return -1;
     }
     ppid = getppid(); // We start with the parent
-    while (ppid != 1) {
+    while (ppid != 0) {
         // Create the path to /proc/<ppid>/stat
         sprintf(stat_path, "/proc/%d/stat", ppid);
         statf = fopen(stat_path, "r");


### PR DESCRIPTION
The implementation of exclude_spawns_of somewhat predates widespread usage of
Linux containers. Before containers, PID 1 was always some sort of an init
process, always there, always called `init`, and it somewhat made sense to
just ignore it.

But with the onset of containers/namespaces, the PID 1 inside an i.e. Docker
container can be any executable that is configured as container's entrypoint.

The solution is to adjust the filter's method and it perform the process name
analysis all the way up to and including PID 1, whatever that process may be.
