### PR TITLE
core/ds/domain: Fix incorrect handling of comments in /etc/hosts

### DIFF
--- a/src/datasource/domain.c
+++ b/src/datasource/domain.c
@@ -115,7 +115,7 @@ int snoopy_datasource_domain (char * const result, char const * const arg)
 
     /* Read line by line */
     const char *linePtr;
-    const char *hashPtr;
+    char *hashPtr;
     char *lineEntryPtr;
     char *savePtr;
     char *domainPtr = NULL;
@@ -125,7 +125,7 @@ int snoopy_datasource_domain (char * const result, char const * const arg)
         /* Is line a comment - ignore everything after '#' character */
         hashPtr = strchr(linePtr, '#');
         if (NULL != hashPtr) {
-            hashPtr = '\0';
+            *hashPtr = '\0';
         }
 
         /* Try to find "hostname." there */


### PR DESCRIPTION
According to /etc/hosts' manpage, comments that don't start at the beginning of
a line should be allowed, but the `hostname` command (at least on Ubuntu 20.04),
or more likely the underlying `getaddrinfo()` function, doesn't actually return
the domain name in that case. Regardless, let's do the right thing here and
extract the domain name successfully anyway.
