### PR TITLE
datasource/cmdline: Fix incorrect max string length determination

### DIFF
--- a/src/datasource/cmdline.c
+++ b/src/datasource/cmdline.c
@@ -36,11 +36,6 @@
 
 
 
-/* Helper */
-#define min(a,b) a<b ? a : b
-
-
-
 /*
  * SNOOPY DATA SOURCE: cmdline
  *
@@ -76,7 +71,11 @@ int snoopy_datasource_cmdline (char * const result, char const * const arg)
         cmdLineSizeSum += strlen(snoopy_inputdatastorage->argv[i]) + 1;
     }
     /* Do not substract the +1 from the last iteration - the last character (most likely a space) will be converted to \0 */
-    cmdLineSizeRet = min((int) SNOOPY_SYSCONF_ARG_MAX, cmdLineSizeSum);
+    if (cmdLineSizeSum > SNOOPY_DATASOURCE_MESSAGE_MAX_SIZE) {
+        cmdLineSizeRet = SNOOPY_DATASOURCE_MESSAGE_MAX_SIZE;
+    } else {
+        cmdLineSizeRet = cmdLineSizeSum;
+    }
 
     /* Initialize cmdLine */
     cmdLine    = malloc(cmdLineSizeRet);

--- a/src/snoopy.h
+++ b/src/snoopy.h
@@ -34,7 +34,7 @@
 #define  _XOPEN_SOURCE   700
 #include <features.h>   /* Needed for GLIBC macros here */
 #include <syslog.h>     /* Needed for syslog defaults */
-#include <unistd.h>     /* Needed for _SC_ARG_MAX constant */
+#include <unistd.h>
 
 
 
@@ -45,15 +45,6 @@
  * LOG_... constants are needed.
  */
 #include "config.h"
-
-
-
-/**
- * SNOOPY_MAX_ARG_LENGTH
- *
- * Maximum length of arguments passed to execv(e) functions
- */
-#define SNOOPY_SYSCONF_ARG_MAX ((-1 == sysconf(_SC_ARG_MAX)) ? 4096 : sysconf(_SC_ARG_MAX))
 
 
 


### PR DESCRIPTION
Fixes #191.