### PR TITLE
datasource/cmdline: Work around an unconventional execve() call (with a NULL argv)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,15 @@
 
 
 
+2021-xx-xx - Version 2.4.xx
+---------------------------
+o Bugfix (GH #201):
+    Work around DirectAdmin's non-conventional execve() call (null argv).
+    (Thanks to Yavuz Aydin (@yavuzaydin @ GitHub) for reporting this issue and
+    for providing access to a reproduction environment to aid the investigation.)
+
+
+
 2021-04-20 - Version 2.4.14
 ---------------------------
 o Bugfix (GH #198):

--- a/src/datasource/cmdline.c
+++ b/src/datasource/cmdline.c
@@ -61,6 +61,13 @@ int snoopy_datasource_cmdline (char * const result, char const * const arg)
     /* Get argument data of execv/e() call */
     snoopy_inputdatastorage = snoopy_inputdatastorage_get();
 
+    /* DirectAdmin does not follow the execve() convention (as described in its man page)
+       and passes NULL argv instead of what it's supposed to do. Let's work around that. */
+    if (snoopy_inputdatastorage->argv == NULL) {
+        n = snprintf(result, SNOOPY_DATASOURCE_MESSAGE_MAX_SIZE, "%s", snoopy_inputdatastorage->filename);
+        return n;
+    }
+
     /* Count number of arguments */
     for (cmdLineArgCount=0 ; *(snoopy_inputdatastorage->argv+cmdLineArgCount) != (char *) 0 ; cmdLineArgCount++);
 


### PR DESCRIPTION
Fixes #201.