### PR TITLE
install: Fix OpenSUSE installer (install `findutils` package if needed)

### DIFF
--- a/dev-tools/install-dev-software.sh
+++ b/dev-tools/install-dev-software.sh
@@ -34,7 +34,7 @@ BOOTSTRAP_GIT_REPO_REQUIRED="false"
 # NOTICE: Certain changes here must potentially be reflected
 # in the ../install/install-snoopy.sh file too.
 #
-       PROGRAM_NAMES="autoconf aclocal  curl           gcc git gzip hostname  libtoolize m4 make ps     socat tar wget"
+       PROGRAM_NAMES="autoconf aclocal  curl find      gcc git gzip hostname  libtoolize m4 make ps     socat tar wget"
   PACKAGE_NAMES_ARCH="autoconf automake curl           gcc git gzip inetutils libtool    m4 make procps socat tar wget"
 PACKAGE_NAMES_DEBIAN="autoconf automake curl           gcc git gzip           libtool    m4 make procps socat tar wget"
 PACKAGE_NAMES_REDHAT="autoconf automake curl           gcc git gzip           libtool    m4 make procps socat tar wget"

--- a/install/install-snoopy.sh
+++ b/install/install-snoopy.sh
@@ -256,13 +256,13 @@ _installPackages()
 #
 #
 
-       PROGRAM_NAMES="gcc gzip make ps     socat tar wget"
-  PACKAGE_NAMES_ARCH="gcc gzip make procps socat tar wget"
-PACKAGE_NAMES_DEBIAN="gcc gzip make procps socat tar wget"
-PACKAGE_NAMES_REDHAT="gcc gzip make procps socat tar wget"
-  PACKAGE_NAMES_SUSE="gcc gzip make procps socat tar wget"
+       PROGRAM_NAMES="find      gcc gzip make ps     socat tar wget"
+  PACKAGE_NAMES_ARCH="          gcc gzip make procps socat tar wget"
+PACKAGE_NAMES_DEBIAN="          gcc gzip make procps socat tar wget"
+PACKAGE_NAMES_REDHAT="          gcc gzip make procps socat tar wget"
+  PACKAGE_NAMES_SUSE="findutils gcc gzip make procps socat tar wget"
 if [ "$SNOOPY_SOURCE_TYPE" == "git" ]; then
-           PROGRAM_NAMES="autoconf aclocal  curl           gcc git gzip hostname  libtoolize m4 make ps     socat tar wget"
+           PROGRAM_NAMES="autoconf aclocal  curl find      gcc git gzip hostname  libtoolize m4 make ps     socat tar wget"
       PACKAGE_NAMES_ARCH="autoconf automake curl           gcc git gzip inetutils libtool    m4 make procps socat tar wget"
     PACKAGE_NAMES_DEBIAN="autoconf automake curl           gcc git gzip           libtool    m4 make procps socat tar wget"
     PACKAGE_NAMES_REDHAT="autoconf automake curl           gcc git gzip           libtool    m4 make procps socat tar wget"


### PR DESCRIPTION
Latest Tumbleweed does not include the `find` utility like it used to.
