### PR TITLE
ci/cd: Refresh/update images used for testing

### DIFF
--- a/.github/workflows/build-qa-config-matrix-large.yml
+++ b/.github/workflows/build-qa-config-matrix-large.yml
@@ -81,6 +81,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Work around the fix for CVE-2022-24765
+      - run: git config --global --add safe.directory $GITHUB_WORKSPACE || true
+
 
 
       ### Build

--- a/.github/workflows/build-qa-config-matrix-small.yml
+++ b/.github/workflows/build-qa-config-matrix-small.yml
@@ -66,6 +66,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Work around the fix for CVE-2022-24765
+      - run: git config --global --add safe.directory $GITHUB_WORKSPACE || true
+
 
 
       ### Build

--- a/.github/workflows/build-qa-os-matrix-large.yml
+++ b/.github/workflows/build-qa-os-matrix-large.yml
@@ -78,6 +78,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Work around the fix for CVE-2022-24765
+      - run: git config --global --add safe.directory $GITHUB_WORKSPACE || true
+
 
 
       ### Build

--- a/.github/workflows/build-qa-os-matrix-large.yml
+++ b/.github/workflows/build-qa-os-matrix-large.yml
@@ -44,20 +44,23 @@ jobs:
         container:
 #          - ciready/archlinux:base-devel-ci-c
 
-          - ciready/centos:7-ci-c
-          - ciready/centos:8-ci-c
+          - ciready/almalinux:8-ci-c
+          - ciready/almalinux:9-ci-c
 
-          - ciready/debian:stretch-ci-c
+          - ciready/centos:stream-8-ci-c
+          - ciready/centos:stream-9-ci-c
+
           - ciready/debian:buster-ci-c
           - ciready/debian:bullseye-ci-c
           - ciready/debian:sid-ci-c
 
-          - ciready/opensuse:leap-15.2-ci-c
           - ciready/opensuse:leap-15.3-ci-c
+          - ciready/opensuse:leap-15.4-ci-c
           - ciready/opensuse:tumbleweed-latest-ci-c
 
           - ciready/ubuntu:18.04-ci-c
           - ciready/ubuntu:20.04-ci-c
+          - ciready/ubuntu:22.04-ci-c
           - ciready/ubuntu:rolling-ci-c
 
 

--- a/.github/workflows/build-qa-os-matrix-small.yml
+++ b/.github/workflows/build-qa-os-matrix-small.yml
@@ -69,6 +69,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Work around the fix for CVE-2022-24765
+      - run: git config --global --add safe.directory $GITHUB_WORKSPACE || true
+
 
 
       ### Build

--- a/.github/workflows/build-qa-os-matrix-small.yml
+++ b/.github/workflows/build-qa-os-matrix-small.yml
@@ -42,14 +42,16 @@ jobs:
         container:
 #          - ciready/archlinux:base-devel-ci-c
 
-          - ciready/centos:8-ci-c
+          - ciready/almalinux:9-ci-c
 
-          - ciready/debian:buster-ci-c
+          - ciready/centos:stream-9-ci-c
+
+          - ciready/debian:bullseye-ci-c
           - ciready/debian:sid-ci-c
 
-          - ciready/opensuse:leap-15.3-ci-c
+          - ciready/opensuse:leap-15.4-ci-c
 
-          - ciready/ubuntu:20.04-ci-c
+          - ciready/ubuntu:22.04-ci-c
           - ciready/ubuntu:rolling-ci-c
 
 

--- a/.github/workflows/build-qa-out-of-tree-build.yml
+++ b/.github/workflows/build-qa-out-of-tree-build.yml
@@ -69,6 +69,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Work around the fix for CVE-2022-24765
+      - run: git config --global --add safe.directory $GITHUB_WORKSPACE || true
+
 
 
       ### Build

--- a/.github/workflows/build-qa-verify-make-targets-prefix.yml
+++ b/.github/workflows/build-qa-verify-make-targets-prefix.yml
@@ -69,6 +69,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Work around the fix for CVE-2022-24765
+      - run: git config --global --add safe.directory $GITHUB_WORKSPACE || true
+
 
 
       ### Build

--- a/.github/workflows/code-qa-autoreconf.yml
+++ b/.github/workflows/code-qa-autoreconf.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Work around the fix for CVE-2022-24765
+      - run: git config --global --add safe.directory $GITHUB_WORKSPACE || true
+
 
 
       ### Install build environment tools

--- a/.github/workflows/code-qa-autoscan.yml
+++ b/.github/workflows/code-qa-autoscan.yml
@@ -56,6 +56,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Work around the fix for CVE-2022-24765
+      - run: git config --global --add safe.directory $GITHUB_WORKSPACE || true
+
 
 
       ### Install build environment tools

--- a/.github/workflows/code-qa-codeql.yml
+++ b/.github/workflows/code-qa-codeql.yml
@@ -56,6 +56,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
+    # Work around the fix for CVE-2022-24765
+    - run: git config --global --add safe.directory $GITHUB_WORKSPACE || true
+
+
     ### Initialize the CodeQL tools for scanning
     #
     - name: Initialize CodeQL

--- a/.github/workflows/code-qa-coverity.yml
+++ b/.github/workflows/code-qa-coverity.yml
@@ -45,6 +45,9 @@ jobs:
         with:
           fetch-depth: 0   # Shallow clones should be disabled for a better relevancy of analysis
 
+      # Work around the fix for CVE-2022-24765
+      - run: git config --global --add safe.directory $GITHUB_WORKSPACE || true
+
 
 
       ### Install build environment tools

--- a/.github/workflows/code-qa-sonarcloud.yml
+++ b/.github/workflows/code-qa-sonarcloud.yml
@@ -95,6 +95,9 @@ jobs:
           ref: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event_name == 'pull_request_target' }}
 
+      # Work around the fix for CVE-2022-24765
+      - run: git config --global --add safe.directory $GITHUB_WORKSPACE || true
+
 
 
       ### Install build environment tools + unzip

--- a/.github/workflows/code-qa-valgrind.yml
+++ b/.github/workflows/code-qa-valgrind.yml
@@ -64,6 +64,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Work around the fix for CVE-2022-24765
+      - run: git config --global --add safe.directory $GITHUB_WORKSPACE || true
+
 
 
       ### Install build environment tools + valgrind

--- a/.github/workflows/install-qa-installfile.yml
+++ b/.github/workflows/install-qa-installfile.yml
@@ -49,6 +49,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Work around the fix for CVE-2022-24765
+      - run: git config --global --add safe.directory $GITHUB_WORKSPACE || true
+
 
 
       ### Install

--- a/.github/workflows/install-qa-os-matrix.yml
+++ b/.github/workflows/install-qa-os-matrix.yml
@@ -78,6 +78,9 @@ jobs:
       #
       - uses: actions/checkout@v2
 
+      # Work around the fix for CVE-2022-24765
+      - run: git config --global --add safe.directory $GITHUB_WORKSPACE || true
+
 
 
       ### Install

--- a/.github/workflows/install-qa-os-matrix.yml
+++ b/.github/workflows/install-qa-os-matrix.yml
@@ -37,20 +37,23 @@ jobs:
         container:
 #          - archlinux:base-devel
 
-          - centos:7
-          - centos:8
+          - almalinux/8-base:latest
+          - almalinux/9-base:latest
 
-          - debian:stretch
+          - quay.io/centos/centos:stream8
+          - quay.io/centos/centos:stream9
+
           - debian:buster
           - debian:bullseye
           - debian:sid
 
-          - opensuse/leap:15.2
           - opensuse/leap:15.3
+          - opensuse/leap:15.4
           - opensuse/tumbleweed:latest
 
           - ubuntu:18.04
           - ubuntu:20.04
+          - ubuntu:22.04
           - ubuntu:rolling
 
 

--- a/.github/workflows/install-qa-readme.yml
+++ b/.github/workflows/install-qa-readme.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Work around the fix for CVE-2022-24765
+      - run: git config --global --add safe.directory $GITHUB_WORKSPACE || true
+
 
 
       ### Install tools required to download and run the script

--- a/.github/workflows/release-qa-os-matrix-install-from-source.yml
+++ b/.github/workflows/release-qa-os-matrix-install-from-source.yml
@@ -30,20 +30,23 @@ jobs:
         container:
 #          - archlinux:base-devel
 
-          - centos:7
-          - centos:8
+          - almalinux/8-base:latest
+          - almalinux/9-base:latest
 
-          - debian:stretch
+          - quay.io/centos/centos:stream8
+          - quay.io/centos/centos:stream9
+
           - debian:buster
           - debian:bullseye
           - debian:sid
 
-          - opensuse/leap:15.2
           - opensuse/leap:15.3
+          - opensuse/leap:15.4
           - opensuse/tumbleweed:latest
 
           - ubuntu:18.04
           - ubuntu:20.04
+          - ubuntu:22.04
           - ubuntu:rolling
 
 
@@ -64,7 +67,7 @@ jobs:
 
       # CentOS
       - run: yum install -y   wget tar gzip
-        if: ${{ startsWith(matrix.container, 'centos:') }}
+        if: ${{ startsWith(matrix.container, 'almalinux/') || startsWith(matrix.container, 'quay.io/centos/centos:') }}
 
       # Debian / Ubuntu
       - run: |

--- a/.github/workflows/release-qa-os-matrix-install-from-source.yml
+++ b/.github/workflows/release-qa-os-matrix-install-from-source.yml
@@ -88,6 +88,9 @@ jobs:
       #
       - uses: actions/checkout@v2
 
+      # Work around the fix for CVE-2022-24765
+      - run: git config --global --add safe.directory $GITHUB_WORKSPACE || true
+
 
 
       ### Install

--- a/dev-tools/install-dev-software.sh
+++ b/dev-tools/install-dev-software.sh
@@ -135,7 +135,7 @@ _installPackages()
             ;;
 
         rhel|centos|almalinux)
-            $USE_SUDO yum install -y $PACKAGE_NAMES_REDHAT
+            $USE_SUDO yum install -y --allowerasing $PACKAGE_NAMES_REDHAT
             ;;
 
         sles|opensuse-leap|opensuse-tumbleweed)

--- a/dev-tools/install-dev-software.sh
+++ b/dev-tools/install-dev-software.sh
@@ -34,11 +34,11 @@ BOOTSTRAP_GIT_REPO_REQUIRED="false"
 # NOTICE: Certain changes here must potentially be reflected
 # in the ../install/install-snoopy.sh file too.
 #
-       PROGRAM_NAMES="autoconf aclocal  curl find      gcc git gzip hostname  libtoolize m4 make ps     socat tar wget"
-  PACKAGE_NAMES_ARCH="autoconf automake curl           gcc git gzip inetutils libtool    m4 make procps socat tar wget"
-PACKAGE_NAMES_DEBIAN="autoconf automake curl           gcc git gzip           libtool    m4 make procps socat tar wget"
-PACKAGE_NAMES_REDHAT="autoconf automake curl           gcc git gzip hostname  libtool    m4 make procps socat tar wget"
-  PACKAGE_NAMES_SUSE="autoconf automake curl findutils gcc git gzip hostname  libtool    m4 make procps socat tar wget"
+       PROGRAM_NAMES="autoconf aclocal  curl diff      file find      gcc git gzip hostname  libtoolize m4 make ps     socat tar wget"
+  PACKAGE_NAMES_ARCH="autoconf automake curl diffutils file           gcc git gzip inetutils libtool    m4 make procps socat tar wget"
+PACKAGE_NAMES_DEBIAN="autoconf automake curl diffutils file           gcc git gzip           libtool    m4 make procps socat tar wget"
+PACKAGE_NAMES_REDHAT="autoconf automake curl diffutils file           gcc git gzip hostname  libtool    m4 make procps socat tar wget"
+  PACKAGE_NAMES_SUSE="autoconf automake curl diffutils file findutils gcc git gzip hostname  libtool    m4 make procps socat tar wget"
 
 
 

--- a/dev-tools/install-dev-software.sh
+++ b/dev-tools/install-dev-software.sh
@@ -134,7 +134,7 @@ _installPackages()
             DEBIAN_FRONTEND="noninteractive" $USE_SUDO apt-get install -y $PACKAGE_NAMES_DEBIAN
             ;;
 
-        rhel|centos)
+        rhel|centos|almalinux)
             $USE_SUDO yum install -y $PACKAGE_NAMES_REDHAT
             ;;
 

--- a/dev-tools/install-dev-software.sh
+++ b/dev-tools/install-dev-software.sh
@@ -37,7 +37,7 @@ BOOTSTRAP_GIT_REPO_REQUIRED="false"
        PROGRAM_NAMES="autoconf aclocal  curl find      gcc git gzip hostname  libtoolize m4 make ps     socat tar wget"
   PACKAGE_NAMES_ARCH="autoconf automake curl           gcc git gzip inetutils libtool    m4 make procps socat tar wget"
 PACKAGE_NAMES_DEBIAN="autoconf automake curl           gcc git gzip           libtool    m4 make procps socat tar wget"
-PACKAGE_NAMES_REDHAT="autoconf automake curl           gcc git gzip           libtool    m4 make procps socat tar wget"
+PACKAGE_NAMES_REDHAT="autoconf automake curl           gcc git gzip hostname  libtool    m4 make procps socat tar wget"
   PACKAGE_NAMES_SUSE="autoconf automake curl findutils gcc git gzip hostname  libtool    m4 make procps socat tar wget"
 
 

--- a/install/install-snoopy.sh
+++ b/install/install-snoopy.sh
@@ -265,7 +265,7 @@ if [ "$SNOOPY_SOURCE_TYPE" == "git" ]; then
            PROGRAM_NAMES="autoconf aclocal  curl find      gcc git gzip hostname  libtoolize m4 make ps     socat tar wget"
       PACKAGE_NAMES_ARCH="autoconf automake curl           gcc git gzip inetutils libtool    m4 make procps socat tar wget"
     PACKAGE_NAMES_DEBIAN="autoconf automake curl           gcc git gzip           libtool    m4 make procps socat tar wget"
-    PACKAGE_NAMES_REDHAT="autoconf automake curl           gcc git gzip           libtool    m4 make procps socat tar wget"
+    PACKAGE_NAMES_REDHAT="autoconf automake curl           gcc git gzip hostname  libtool    m4 make procps socat tar wget"
       PACKAGE_NAMES_SUSE="autoconf automake curl findutils gcc git gzip hostname  libtool    m4 make procps socat tar wget"
 fi
 

--- a/install/install-snoopy.sh
+++ b/install/install-snoopy.sh
@@ -226,7 +226,7 @@ _installPackages()
             DEBIAN_FRONTEND="noninteractive" $USE_SUDO apt-get install -y $PACKAGE_NAMES_DEBIAN
             ;;
 
-        rhel|centos)
+        rhel|centos|almalinux)
             $USE_SUDO yum install -y $PACKAGE_NAMES_REDHAT
             ;;
 

--- a/tests/filter/filter_exclude_spawns_of-mustdrop-multiarg-first.sh
+++ b/tests/filter/filter_exclude_spawns_of-mustdrop-multiarg-first.sh
@@ -17,7 +17,7 @@ set -u
 #
 PARENT_PROC_NAME="bash"
 . /etc/os-release
-if [[ $ID =~ ^(arch|centos|opensuse) ]]; then
+if [[ $ID =~ ^(arch|almalinux|centos|opensuse) ]]; then
     PARENT_PROC_NAME="sh"
 fi
 

--- a/tests/filter/filter_exclude_spawns_of-mustdrop-multiarg-last.sh
+++ b/tests/filter/filter_exclude_spawns_of-mustdrop-multiarg-last.sh
@@ -17,7 +17,7 @@ set -u
 #
 PARENT_PROC_NAME="bash"
 . /etc/os-release
-if [[ $ID =~ ^(arch|centos|opensuse) ]]; then
+if [[ $ID =~ ^(arch|almalinux|centos|opensuse) ]]; then
     PARENT_PROC_NAME="sh"
 fi
 

--- a/tests/filter/filter_exclude_spawns_of-mustdrop-multiarg-mid.sh
+++ b/tests/filter/filter_exclude_spawns_of-mustdrop-multiarg-mid.sh
@@ -17,7 +17,7 @@ set -u
 #
 PARENT_PROC_NAME="bash"
 . /etc/os-release
-if [[ $ID =~ ^(arch|centos|opensuse) ]]; then
+if [[ $ID =~ ^(arch|almalinux|centos|opensuse) ]]; then
     PARENT_PROC_NAME="sh"
 fi
 

--- a/tests/filter/filter_exclude_spawns_of-mustdrop-singlearg.sh
+++ b/tests/filter/filter_exclude_spawns_of-mustdrop-singlearg.sh
@@ -17,7 +17,7 @@ set -u
 #
 PARENT_PROC_NAME="bash"
 . /etc/os-release
-if [[ $ID =~ ^(arch|centos|opensuse) ]]; then
+if [[ $ID =~ ^(arch|almalinux|centos|opensuse) ]]; then
     PARENT_PROC_NAME="sh"
 fi
 


### PR DESCRIPTION
Done:
- Replace CentOS 7 & 8 with AlmaLinux 8 & 9,
- Introduce CentOS stream8 & stream9
- Deprecate Debian stretch
- Deprecate openSuse Leap 15.2 & introduce openSUSE Leap 15.4
- Introduce Ubuntu 22.04
