### PR TITLE
ext/list: Fix the last remaining code smell(s)

### DIFF
--- a/lib/liblcthw/patches/0005-fix-sq-code-smells.diff
+++ b/lib/liblcthw/patches/0005-fix-sq-code-smells.diff
@@ -1,0 +1,31 @@
+--- src/list.c
++++ src/list.c
+@@ -37,7 +37,7 @@ void List_clear_destroy(List *list)
+ void List_push(List *list, void *value)
+ {
+     ListNode *node = calloc(1, sizeof(ListNode));
+-    check_mem(node);
++    check_mem(node)
+ 
+     node->value = value;
+ 
+@@ -67,7 +67,7 @@ void *List_pop(List *list)
+ void List_shift(List *list, void *value)
+ {
+     ListNode *node = calloc(1, sizeof(ListNode));
+-    check_mem(node);
++    check_mem(node)
+ 
+     node->value = value;
+ 
+@@ -96,8 +96,8 @@ void *List_remove(List *list, ListNode *node)
+ {
+     void *result = NULL;
+ 
+-    check(list->first && list->last, "List is empty.%s", "");
+-    check(node, "Node can't be NULL.%s", "");
++    check(list->first && list->last, "List is empty.%s", "")
++    check(node, "Node can't be NULL.%s", "")
+ 
+     if(node == list->first && node == list->last) {
+         list->first = NULL;

--- a/lib/liblcthw/src/list.c
+++ b/lib/liblcthw/src/list.c
@@ -37,7 +37,7 @@ void List_clear_destroy(List *list)
 void List_push(List *list, void *value)
 {
     ListNode *node = calloc(1, sizeof(ListNode));
-    check_mem(node);
+    check_mem(node)
 
     node->value = value;
 
@@ -67,7 +67,7 @@ void *List_pop(List *list)
 void List_shift(List *list, void *value)
 {
     ListNode *node = calloc(1, sizeof(ListNode));
-    check_mem(node);
+    check_mem(node)
 
     node->value = value;
 
@@ -96,8 +96,8 @@ void *List_remove(List *list, ListNode *node)
 {
     void *result = NULL;
 
-    check(list->first && list->last, "List is empty.%s", "");
-    check(node, "Node can't be NULL.%s", "");
+    check(list->first && list->last, "List is empty.%s", "")
+    check(node, "Node can't be NULL.%s", "")
 
     if(node == list->first && node == list->last) {
         list->first = NULL;


### PR DESCRIPTION
The macro in question is expanded into `if(...){...}`, thus suffixing the macro
statement with a semicolon creates and empty statement (between `}` and `;`).

SQ/SC references:
- https://sonarcloud.io/project/issues?issues=AXjNfUfBZ-ncPEFTe1Ib&open=AXjNfUfBZ-ncPEFTe1Ib&id=snoopy
- https://sonarcloud.io/project/issues?issues=AXjNfUfBZ-ncPEFTe1Ic&open=AXjNfUfBZ-ncPEFTe1Ic&id=snoopy
- https://sonarcloud.io/project/issues?issues=AXjNfUfBZ-ncPEFTe1Id&open=AXjNfUfBZ-ncPEFTe1Id&id=snoopy
- https://sonarcloud.io/project/issues?issues=AXjNfUfBZ-ncPEFTe1Ie&open=AXjNfUfBZ-ncPEFTe1Ie&id=snoopy
