### PR TITLE
core: Add support for dynamic output file paths 

### DIFF
--- a/etc/snoopy.ini.in
+++ b/etc/snoopy.ini.in
@@ -136,6 +136,9 @@
 ;output = devtty
 ;output = devlog
 ;output = file:/var/log/snoopy.log
+;output = file:/var/log/snoopy.log-%{datetime:%Y-%m-%d}
+;output = file:/var/log/snoopy.log-%{username}
+;output = file:/home/%{username}/snoopy.log   ; If "/home/%{username}" directory does not exist, Snoopy will _not_ create it.
 ;output = socket:/var/run/socket-for-snoopy.sock
 
 

--- a/src/action/log-syscall-exec.c
+++ b/src/action/log-syscall-exec.c
@@ -54,7 +54,7 @@
  */
 void snoopy_action_log_syscall_exec ()
 {
-    snoopy_configuration_t *CFG;
+    const snoopy_configuration_t * CFG;
     char *logMessage = NULL;
 
     /* Get config pointer */

--- a/src/message.c
+++ b/src/message.c
@@ -48,19 +48,20 @@
  *
  * Params:
  *     logMessage:         destination string to return message in
+ *     logMessageBufSize:  size of the destination buffer
  *     logMessageFormat:   log message format to use
  *
  * Return:
  *     void
  */
 void snoopy_message_generateFromFormat (
-    char  *logMessage,
-    size_t logMessageBufSize,
-    char  *logMessageFormat
+    char * const logMessage,
+    size_t       logMessageBufSize,
+    char const * const logMessageFormat
 ) {
-    char *fmtPos_cur;
-    char *fmtPos_nextFormatTag;
-    char *fmtPos_nextFormatTagClose;
+    char const * fmtPos_cur;
+    char const * fmtPos_nextFormatTag;
+    char const * fmtPos_nextFormatTagClose;
     int   retVal;
 
     fmtPos_cur           = logMessageFormat;
@@ -161,9 +162,9 @@ void snoopy_message_generateFromFormat (
  *     void
  */
 void snoopy_message_append (
-    char  *logMessage,
+    char * logMessage,
     size_t logMessageBufSize,
-    const char *appendThis
+    char const * const appendThis
 ) {
     if (SNOOPY_ERROR == snoopy_util_string_append(logMessage, logMessageBufSize, appendThis)) {
         snoopy_error_handler("Maximum destination string size exceeded");

--- a/src/message.h
+++ b/src/message.h
@@ -27,15 +27,15 @@
 
 
 void snoopy_message_generateFromFormat (
-    char       *logMessage,
-    size_t      logMessageBufSize,
-    char       *logMessageFormat
+    char * const       logMessage,
+    size_t             logMessageBufSize,
+    char const * const logMessageFormat
 );
 
 
 
 void snoopy_message_append (
-    char       *logMessage,
-    size_t      logMessageBufSize,
-    const char *appendThis
+    char * const       logMessage,
+    size_t             logMessageBufSize,
+    char const * const appendThis
 );

--- a/src/output/devlogoutput.c
+++ b/src/output/devlogoutput.c
@@ -60,7 +60,7 @@ int snoopy_output_devlogoutput (char const * const logMessage, __attribute__((un
     }
 
     /* Get config pointer */
-    snoopy_configuration_t *CFG = snoopy_configuration_get();
+    const snoopy_configuration_t * CFG = snoopy_configuration_get();
 
     /* Generate syslog ident string */
     char syslogIdent[SNOOPY_SYSLOG_IDENT_FORMAT_BUF_SIZE] = {'\0'};

--- a/src/output/fileoutput.c
+++ b/src/output/fileoutput.c
@@ -29,7 +29,9 @@
 
 #include "snoopy.h"
 #include "configuration.h"
+#include "message.h"
 
+#include <linux/limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -51,6 +53,8 @@
  */
 int snoopy_output_fileoutput (char const * const logMessage, char const * const arg)
 {
+    char   filePathBuf[PATH_MAX] = {'\0'};
+    char * filePath = filePathBuf;
     FILE  *fp;
     int    charCount;
 
@@ -59,8 +63,11 @@ int snoopy_output_fileoutput (char const * const logMessage, char const * const 
         return SNOOPY_OUTPUT_FAILURE;
     }
 
+    // Parse the output file specification (i.e. for %{datetime} or similar tags)
+    snoopy_message_generateFromFormat(filePath, PATH_MAX, arg);
+
     // Try to open file in append mode
-    fp = fopen(arg, "a");
+    fp = fopen(filePath, "a");
     if (NULL == fp) {
         return SNOOPY_OUTPUT_FAILURE;
     }

--- a/src/output/syslogoutput.c
+++ b/src/output/syslogoutput.c
@@ -61,7 +61,7 @@ int snoopy_output_syslogoutput (char const * const logMessage, __attribute__((un
     }
 
     /* Get config pointer */
-    snoopy_configuration_t *CFG = snoopy_configuration_get();
+    const snoopy_configuration_t * CFG = snoopy_configuration_get();
 
     /* Generate syslog ident string */
     char syslogIdent[SNOOPY_SYSLOG_IDENT_FORMAT_BUF_SIZE] = {'\0'};

--- a/tests/bin/action-run-everything.c
+++ b/tests/bin/action-run-everything.c
@@ -69,7 +69,7 @@ void snoopyTestCli_action_run_everything_showHelp ()
 int snoopyTestCli_action_run_everything ()
 {
     char                     *logMessage = NULL;
-    snoopy_configuration_t   *CFG;
+    const snoopy_configuration_t * CFG;
 
 
     /* Initialize Snoopy */

--- a/tests/bin/action-run-messageformat.c
+++ b/tests/bin/action-run-messageformat.c
@@ -58,8 +58,8 @@ void snoopyTestCli_action_run_messageformat_showHelp ()
 
 int snoopyTestCli_action_run_messageformat (int argc, char **argv)
 {
-    char *messageFormat;
-    char *message;
+    const char * messageFormat;
+    char       * message;
 
 
     /* Initialize Snoopy */

--- a/tests/output/Makefile.am
+++ b/tests/output/Makefile.am
@@ -15,6 +15,9 @@ endif
 
 if OUTPUT_ENABLED_file
     TESTS += output_file.sh
+if DATASOURCE_ENABLED_username
+    TESTS += output_file-dynamic.sh
+endif
 endif
 
 TESTS += output_noop.sh

--- a/tests/output/output_file-dynamic.sh
+++ b/tests/output/output_file-dynamic.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+
+
+### Configure shell and bootstrap
+#
+set -e
+set -u
+. `dirname $BASH_SOURCE`/_bootstrap.sh
+
+
+
+### Output data
+#
+VAL_REAL=`date +%s`
+MY_PID=$$
+MY_USERNAME=`whoami`
+FILE_EXPECTED="output_file-dynamic.sh.$MY_PID-$MY_USERNAME.tmp.out"
+FILE_FORMAT="output_file-dynamic.sh.$MY_PID-%{username}.tmp.out"
+
+# Write
+rm -f $FILE_EXPECTED
+$SNOOPY_TEST_CLI run output   "$VAL_REAL"   "file"   "$FILE_FORMAT" > /dev/null
+
+# Read
+VAL_SNOOPY=`cat $FILE_EXPECTED`
+rm -f $FILE_EXPECTED
+
+
+
+### Evaluate
+#
+snoopy_test_compareValues "$VAL_SNOOPY" "$VAL_REAL"


### PR DESCRIPTION
(i.e. `/var/log/snoopy.log-%{datetime:%Y-%m-%d}`)

(Fixes GitHub issue #229.)
