### PR TITLE
ci: Error out if an unknown `./configure` option is encountered

### DIFF
--- a/.github/workflows/build-qa-config-matrix-large.yml
+++ b/.github/workflows/build-qa-config-matrix-large.yml
@@ -91,10 +91,10 @@ jobs:
       - run: ./dev-tools/install-dev-software.sh
       - run: ./bootstrap.sh
 
-      - run: ./configure ${{matrix.configure_flags}}
+      - run: ./configure --enable-option-checking=fatal ${{matrix.configure_flags}}
         if: ${{ ! startsWith(matrix.configure_flags, 'random') }}
 
-      - run: ./configure `./dev-tools/libexec/get-random-configure-flags.sh`
+      - run: ./configure --enable-option-checking=fatal `./dev-tools/libexec/get-random-configure-flags.sh`
         if: ${{ startsWith(matrix.configure_flags, 'random') }}
 
       - run: make -j4

--- a/.github/workflows/build-qa-config-matrix-small.yml
+++ b/.github/workflows/build-qa-config-matrix-small.yml
@@ -76,10 +76,10 @@ jobs:
       - run: ./dev-tools/install-dev-software.sh
       - run: ./bootstrap.sh
 
-      - run: ./configure ${{matrix.configure_flags}}
+      - run: ./configure --enable-option-checking=fatal ${{matrix.configure_flags}}
         if: ${{ ! startsWith(matrix.configure_flags, 'random') }}
 
-      - run: ./configure `./dev-tools/libexec/get-random-configure-flags.sh`
+      - run: ./configure --enable-option-checking=fatal `./dev-tools/libexec/get-random-configure-flags.sh`
         if: ${{ startsWith(matrix.configure_flags, 'random') }}
 
       - run: make -j4

--- a/.github/workflows/build-qa-os-matrix-large.yml
+++ b/.github/workflows/build-qa-os-matrix-large.yml
@@ -87,7 +87,7 @@ jobs:
       #
       - run: ./dev-tools/install-dev-software.sh
       - run: ./bootstrap.sh
-      - run: ./configure --enable-everything
+      - run: ./configure --enable-option-checking=fatal --enable-everything
       - run: make -j4
       - run: make -j4 check
 

--- a/.github/workflows/build-qa-os-matrix-small.yml
+++ b/.github/workflows/build-qa-os-matrix-small.yml
@@ -78,7 +78,7 @@ jobs:
       #
       - run: ./dev-tools/install-dev-software.sh
       - run: ./bootstrap.sh
-      - run: ./configure --enable-everything
+      - run: ./configure --enable-option-checking=fatal --enable-everything
       - run: make -j4
       - run: make -j4 check
 

--- a/.github/workflows/build-qa-out-of-tree-build.yml
+++ b/.github/workflows/build-qa-out-of-tree-build.yml
@@ -79,7 +79,7 @@ jobs:
       - run: ./dev-tools/install-dev-software.sh
       - run: ./bootstrap.sh
       - run: mkdir -p tmp/build1
-      - run: cd tmp/build1 && ../../configure --enable-everything
+      - run: cd tmp/build1 && ../../configure --enable-option-checking=fatal --enable-everything
       - run: cd tmp/build1 && make -j4
       - run: cd tmp/build1 && make -j4 check
 

--- a/.github/workflows/build-qa-verify-make-targets-prefix.yml
+++ b/.github/workflows/build-qa-verify-make-targets-prefix.yml
@@ -78,7 +78,7 @@ jobs:
       #
       - run: ./dev-tools/install-dev-software.sh
       - run: ./bootstrap.sh
-      - run: ./configure --enable-everything
+      - run: ./configure --enable-option-checking=fatal --enable-everything
       - run: make -j4
 
 

--- a/.github/workflows/code-qa-codeql.yml
+++ b/.github/workflows/code-qa-codeql.yml
@@ -70,7 +70,7 @@ jobs:
     ### Build
     #
     - run: ./bootstrap.sh
-    - run: ./configure --enable-everything
+    - run: ./configure --enable-option-checking=fatal --enable-everything
     - run: make -j4
 
     ### Run the scan

--- a/.github/workflows/code-qa-coverity.yml
+++ b/.github/workflows/code-qa-coverity.yml
@@ -72,7 +72,7 @@ jobs:
       ### Configure
       #
       - run: ./bootstrap.sh
-      - run: ./configure --enable-everything
+      - run: ./configure --enable-option-checking=fatal --enable-everything
 
 
 

--- a/.github/workflows/code-qa-sonarcloud.yml
+++ b/.github/workflows/code-qa-sonarcloud.yml
@@ -120,7 +120,7 @@ jobs:
       ### Bootstrap & configure the code
       #
       - run: ./bootstrap.sh
-      - run: ./configure --enable-everything --enable-code-coverage
+      - run: ./configure --enable-option-checking=fatal --enable-everything --enable-code-coverage
 
 
 

--- a/.github/workflows/code-qa-valgrind.yml
+++ b/.github/workflows/code-qa-valgrind.yml
@@ -79,7 +79,7 @@ jobs:
       ### Build
       #
       - run: ./bootstrap.sh
-      - run: ./configure --enable-everything
+      - run: ./configure --enable-option-checking=fatal --enable-everything
       - run: make
 
 


### PR DESCRIPTION
GNU suggests this option should not be enabled by default, since identical
options are passed into subdirectories containing `configure` scripts (i.e.
if someone is importing Snoopy into their main project and building it in
the main project's subdirectory).

(That said, I wanted to enable this option for everybody regardless of the
suggestion above, but I could not find a way to do it.)