### PR TITLE
packaging/ubuntu: Add AppArmor profile adjustment for snapd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,8 +64,6 @@ Makefile
 /tests/bin/snoopy-test
 /tests/bin/spaceparent
 /tests/bin/space parent
-/packaging/rhel/snoopy.spec
-/packaging/sles/snoopy.spec
 /etc/snoopy.ini
 
 
@@ -112,6 +110,12 @@ Makefile
 # Debian
 /debian
 /packaging/deb/changelog
+/packaging/deb/.debhelper/
+/packaging/deb/autoreconf.after
+/packaging/deb/autoreconf.before
+/packaging/deb/debhelper-build-stamp
+/packaging/deb/snoopy.debhelper.log
+/packaging/deb/snoopy/
 #../snoopy_*_*.buildinfo
 #../snoopy_*_*.changes
 #../snoopy_*_*.deb

--- a/packaging/deb/extra-files/snapd-apparmor-profile
+++ b/packaging/deb/extra-files/snapd-apparmor-profile
@@ -1,0 +1,26 @@
+#
+# Ubuntu Snap AppArmor profile additions by Snoopy Command Logger
+#
+# Snoopy installation from .deb currently does not reload apparmor profiles.
+# You will either need to do that manually, or reboot the whole system.
+#
+# Additionally, once "inside" snap, Snoopy is unable to read /etc/snoopy.ini
+# on the host's filesystem, which makes it revert back to the built-in default
+# configuration.
+#
+    /lib/x86_64-linux-gnu/libsnoopy.so* mr,
+    /etc/snoopy.ini r,
+
+    /dev/pts/ r,
+    /proc/*/loginuid r,
+    /proc/[0-9]+/status r,
+    /usr/lib/x86_64-linux-gnu/libnss_compat-*.so mr,
+    /usr/lib/x86_64-linux-gnu/libnss_nis-*.so mr,
+    /usr/lib/x86_64-linux-gnu/libnsl-*.so mr,
+
+    unix (create, connect, send) type=dgram,
+    unix (create, connect, send) type=stream,
+
+    /dev/log w,
+    /run/systemd/journal/dev-log w,
+    /var/log/snoopy.log w,

--- a/packaging/deb/rules
+++ b/packaging/deb/rules
@@ -2,8 +2,13 @@
 
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+
+OS_ID = $(shell cat /etc/os-release | grep ^ID= | cut -d= -f2)
+
+
 %:
 	dh $@
+
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
@@ -12,14 +17,24 @@ override_dh_auto_configure:
 		--sysconfdir=/etc \
 		--with-message-format='[login:%{login} ssh:(%{env:SSH_CONNECTION}) sid:%{sid} tty:%{tty} (%{tty_uid}/%{tty_username}) uid:%{username}(%{uid})/%{eusername}(%{euid}) cwd:%{cwd}]: %{cmdline}'
 
+
 override_dh_auto_install:
 	dh_auto_install
+	
 	find debian/ -name "*.la" -delete
+	
+	@if [ "$(OS_ID)" = "ubuntu" ] ; then \
+	    mkdir -p                                     debian/snoopy/var/lib/snapd/apparmor/snap-confine ; \
+	    cp debian/extra-files/snapd-apparmor-profile debian/snoopy/var/lib/snapd/apparmor/snap-confine/snoopy ; \
+	fi
+
 
 override_dh_clean:
 	dh_clean
+	
 	find . -name Makefile.in -exec rm {} \+
 	rm -f aclocal.m4 compile configure test-drive
+
 
 override_dh_missing:
 	dh_missing --fail-missing


### PR DESCRIPTION
We're only adding this to a packaged Snoopy version (Ubuntu only for now),
and not to stock .tar.gz distribution, since this is a distribution-related
matter.

Related to issue #237.
