### PR TITLE
tests/bin/threads: Fix non-explicit casting that caused non-64bit builds to fail 

### DIFF
--- a/.github/workflows/build-qa-arch-matrix.yml
+++ b/.github/workflows/build-qa-arch-matrix.yml
@@ -1,0 +1,120 @@
+name: Build QA - Arch Matrix
+
+
+
+on:
+  workflow_dispatch:
+
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '**'
+      - '!.github/**'
+      - '.github/workflows/build-qa-arch-matrix.yml'
+      - '!.gitignore'
+      - '!ChangeLog'
+      - '!COPYING'
+      - '!configure.scan'
+      - '!dev-tools/**'
+      - 'dev-tools/install-dev-software.sh'
+      - 'dev-tools/libexec/get-release-*.sh'
+      - '!doc/**'
+      - '!etc/**'
+      - '!install/**'
+      - '!lib/*/IMPORT.defs'
+      - '!lib/*/LICENSE'
+      - '!README.md'
+
+  push:
+    branches:
+      - master
+      - force-github-action-run
+    tags:
+      - '*'
+    paths:
+      - '**'
+      - '!.github/**'
+      - '.github/workflows/build-qa-arch-matrix.yml'
+      - '!.gitignore'
+      - '!ChangeLog'
+      - '!COPYING'
+      - '!configure.scan'
+      - '!dev-tools/**'
+      - 'dev-tools/install-dev-software.sh'
+      - 'dev-tools/libexec/get-release-*.sh'
+      - '!doc/**'
+      - '!etc/**'
+      - '!install/**'
+      - '!lib/*/IMPORT.defs'
+      - '!lib/*/LICENSE'
+      - '!README.md'
+
+
+
+jobs:
+  build-qa-arch-matrix:
+
+
+
+    ### Define the matrix of architectures/platforms to run on
+    #
+    strategy:
+      matrix:
+        include:
+          - arch: linux/386
+            libdir: /lib/i386-linux-gnu
+          - arch: linux/amd64
+            libdir: /lib/x86_64-linux-gnu
+
+
+
+    ### Define the environment to run in
+    #
+    name: Build on ${{matrix.arch}}
+    runs-on: ubuntu-20.04
+    container:
+        image: debian:bullseye
+        options: --platform ${{ matrix.arch }}
+
+
+
+    ###
+    ### Steps to run
+    ###
+    steps:
+
+
+
+      ### Fetch the code
+      #
+      # We're using @v1 here to support execution on 32-bit systems
+      #
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 0
+
+      # Work around the fix for CVE-2022-24765
+      - run: git config --global --add safe.directory $GITHUB_WORKSPACE || true
+
+
+
+      ### Make sure we're running on the right platform
+      #
+      - run: ls -lad ${{ matrix.libdir }}
+
+
+
+      ### Build
+      #
+      - run: ./dev-tools/install-dev-software.sh
+      - run: ./bootstrap.sh
+      - run: ./configure --enable-option-checking=fatal --enable-everything
+      - run: make -j4
+      - run: make -j4 check
+
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: tests-directory
+          path: tests/

--- a/tests/bin/action-stress-threads.c
+++ b/tests/bin/action-stress-threads.c
@@ -298,7 +298,9 @@ int snoopyTestCli_action_stress_threads_randomNumberInclusive (int nMin, int nMa
     bytesRead = read(fd, buffer, sizeof(randomNrRaw));
     close(fd);
     if (bytesRead != sizeof(randomNrRaw)) {
-        printf("ERROR: Unable to read %lu bytes from /dev/urandom, only got %li bytes.\n", sizeof(randomNrRaw), bytesRead);
+        // SonarCloud may complain about redundant casts here, but removing these
+        // "redundant" casts causes builds to fail on non-64bit platforms.
+        printf("ERROR: Unable to read %lu bytes from /dev/urandom, only got %li bytes.\n", (long unsigned) sizeof(randomNrRaw), (long int) bytesRead);
         return -1;
     }
 

--- a/tests/bin/action-stress-threadsexec.c
+++ b/tests/bin/action-stress-threadsexec.c
@@ -162,7 +162,9 @@ int snoopyTestCli_action_stress_threadsexec (int argc, char ** argv)
         .tv_nsec = 100000000,
     };
 
-    if (verbose) printf("M: Waiting for all threads to finish (max %d * %ld ns):\n", pMax, sleepTime.tv_nsec);
+    // SonarCloud may complain about redundant casts here, but removing these
+    // "redundant" casts causes builds to fail on non-64bit platforms.
+    if (verbose) printf("M: Waiting for all threads to finish (max %d * %lld ns):\n", pMax, (long long int) sleepTime.tv_nsec);
     if (verbose) fflush(stdout);
     int p;
     for (p=1 ; p<pMax ; p++) {
@@ -194,13 +196,17 @@ int snoopyTestCli_action_stress_threadsexec (int argc, char ** argv)
             break;
         }
 
-        if (verbose) printf(" M: Not all threads have joined yet, sleeping for %ld ns now.\n", sleepTime.tv_nsec);
+        // SonarCloud may complain about redundant casts here, but removing these
+        // "redundant" casts causes builds to fail on non-64bit platforms.
+        if (verbose) printf(" M: Not all threads have joined yet, sleeping for %lld ns now.\n", (long long int) sleepTime.tv_nsec);
         if (verbose) fflush(stdout);
         nanosleep(&sleepTime, NULL);
     }
 
     if (p >= pMax) {
-        printf("M: ERROR - Not all threads have joined (timeout after %d * %ld ns).\n", pMax, sleepTime.tv_nsec);
+        // SonarCloud may complain about redundant casts here, but removing these
+        // "redundant" casts causes builds to fail on non-64bit platforms.
+        printf("M: ERROR - Not all threads have joined (timeout after %d * %lld ns).\n", pMax, (long long int) sleepTime.tv_nsec);
         return 1;
     }
 


### PR DESCRIPTION
(i.e. in 32-bit Debian Sid container)
