### PR TITLE
Enable SonarCloud analysis cache

### DIFF
--- a/.github/workflows/code-qa-sonarcloud.yml
+++ b/.github/workflows/code-qa-sonarcloud.yml
@@ -190,7 +190,6 @@ jobs:
               -Dsonar.projectVersion=$SONARCLOUD_TAG \
               -Dsonar.cfamily.build-wrapper-output=../snoopy-sonarcloud-build-wrapper-output \
               -Dsonar.cfamily.gcov.reportsPath=. \
-              -Dsonar.cfamily.cache.enabled=false \
               -Dsonar.host.url=https://sonarcloud.io
             echo "Submission tag: $SONARCLOUD_TAG (branch: $CURRENT_BRANCH_NAME)"
         env:
@@ -216,7 +215,6 @@ jobs:
               -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }} \
               -Dsonar.cfamily.build-wrapper-output=../snoopy-sonarcloud-build-wrapper-output \
               -Dsonar.cfamily.gcov.reportsPath=. \
-              -Dsonar.cfamily.cache.enabled=false \
               -Dsonar.host.url=https://sonarcloud.io
             echo "Submission tag: $SONARCLOUD_TAG (branch: $CURRENT_BRANCH_NAME)"
         env:

--- a/dev-tools/submit-to-sonarcloud.sh
+++ b/dev-tools/submit-to-sonarcloud.sh
@@ -115,6 +115,5 @@ sonar-scanner \
   -Dsonar.projectVersion=$SONARCLOUD_TAG \
   -Dsonar.cfamily.build-wrapper-output=$BUILD_WRAPPER_OUTPUT_DIR \
   -Dsonar.cfamily.gcov.reportsPath=. \
-  -Dsonar.cfamily.cache.enabled=false \
   -Dsonar.host.url=https://sonarcloud.io
 echo "INFO: Submission tag: $SONARCLOUD_TAG (branch: $CURRENT_BRANCH_NAME)"


### PR DESCRIPTION

Checklists for Pull requests
----------------------------

About pull request itself:
- [X] I am submitting a pull request! :)
- [X] My submission does one logical thing only (one bugfix, one new feature). If I will want to supply multiple logical changes, I will submit multiple pull requests.
- [X] I have read and understood the [CONTRIBUTING guide](https://github.com/a2o/snoopy/blob/master/.github/CONTRIBUTING.md)

Code quality:
(not applicable for non-code fixes)
- [X] My submission is passing the test suite run (./configure --enable-everything && make tests) - test suite reports zero unexpected failures.

Commits:
- [X] My commits are logical, easily readable, and with concise comments.
- [X] My commits follow the KISS principle: do one thing, and do it well.

Licensing:
- [X] I am the author of this submission or I have been authorized by the submission copyright holder to issue this pull request. By issuing this pull request the copyright holder agrees that their contribution is included in Snoopy and released under the current Snoopy license (currently GPLv2).

Branching:
- [X] My submission is based on `master` branch.
- [X] My submission is compatible with the latest `master` branch (no conflicts, I did a rebase if it was necessary).
- [X] The name of the branch I want to merge upstream is not `master`.
- [ ] My branch name is `feature/my-shiny-new-snoopy-feature-title` (for new features).
- [ ] My branch name is `bugfix/my-totally-non-hackish-workaround` (for bugfixes).
- [ ] My branch name is `doc/what-i-did-to-documentation` (for documentation updates).

Continuous integration:
- [ ] Once I submit this pull request, I will wait for a CI report (normally done in a few minutes) and fix any issues CI points out.



Pull request description
------------------------

SonarCloud now has an automatic analysis caching which gets saved on the server. See https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/#analysis-cache.
