### PR TITLE
Use strnlen instead of strlen

### DIFF
--- a/configure.scan
+++ b/configure.scan
@@ -30,6 +30,7 @@ AC_TYPE_UID_T
 AC_FUNC_FORK
 AC_FUNC_MALLOC
 AC_FUNC_STRERROR_R
+AC_FUNC_STRNLEN
 AC_CHECK_FUNCS([getcwd gethostname gettimeofday localtime_r socket strchr strdup strerror strndup strrchr strstr utmpname])
 
 AC_CONFIG_FILES([Makefile

--- a/src/output/socketoutput.c
+++ b/src/output/socketoutput.c
@@ -39,6 +39,7 @@
 #include <sys/un.h>
 #include <unistd.h>
 
+#define PATH_SIZE    107
 
 
 /*
@@ -76,12 +77,11 @@ int snoopy_output_socketoutput (char const * const logMessage, char const * cons
     }
 
     remote.sun_family = AF_LOCAL;
-    strncpy(remote.sun_path, arg, 107);   // Coverity suggests -1 here
-    if (strlen(arg) > 107) {
-        remote.sun_path[107] = '\0';
-    }
+    strncpy(remote.sun_path, arg, PATH_SIZE);   // Coverity suggests -1 here
+    if (strlen(arg) > PATH_SIZE)
+        remote.sun_path[PATH_SIZE] = '\0';
 
-    remoteLength      = (int) strlen(remote.sun_path) + (int) sizeof(remote.sun_family);
+    remoteLength = (int) strnlen(remote.sun_path, PATH_SIZE) + (int) sizeof(remote.sun_family);
     if (connect(s, (struct sockaddr *)&remote, remoteLength) == -1) {
         close(s);
         return SNOOPY_OUTPUT_FAILURE;


### PR DESCRIPTION
Checklists for Pull requests
----------------------------

About pull request itself:
- [X] I am submitting a pull request! :)
- [X] My submission does one logical thing only (one bugfix, one new feature). If I will want to supply multiple logical changes, I will submit multiple pull requests.
- [X] I have read and understood the [CONTRIBUTING guide](https://github.com/a2o/snoopy/blob/master/.github/CONTRIBUTING.md)

Code quality:
(not applicable for non-code fixes)
- [X] My submission is passing the test suite run (./configure --enable-everything && make tests) - test suite reports zero unexpected failures.

Commits:
- [X] My commits are logical, easily readable, and with concise comments.
- [X] My commits follow the KISS principle: do one thing, and do it well.

Licensing:
- [X] I am the author of this submission or I have been authorized by the submission copyright holder to issue this pull request. By issuing this pull request the copyright holder agrees that their contribution is included in Snoopy and released under the current Snoopy license (currently GPLv2).

Branching:
- [X] My submission is based on `master` branch.
- [X] My submission is compatible with the latest `master` branch (no conflicts, I did a rebase if it was necessary).
- [ ] The name of the branch I want to merge upstream is not `master`.
- [ ] My branch name is `feature/my-shiny-new-snoopy-feature-title` (for new features).
- [X] My branch name is `bugfix/my-totally-non-hackish-workaround` (for bugfixes).
- [ ] My branch name is `doc/what-i-did-to-documentation` (for documentation updates).

Continuous integration:
- [X] Once I submit this pull request, I will wait for a CI report (normally done in a few minutes) and fix any issues CI points out.



Pull request description
------------------------
On older gcc we can get a stringop-overflow warning, since it trying to predict a nonstring overflow. It could be fixed with strnlen() function.

