### PR TITLE
ci/packaging: Disable Arch Linux-related packaging Actions

### DIFF
--- a/.github/workflows/packaging-qa-os-matrix-large.yml
+++ b/.github/workflows/packaging-qa-os-matrix-large.yml
@@ -46,7 +46,8 @@ jobs:
     strategy:
       matrix:
         container:
-          - ciready/archlinux:base-devel-ci-c
+          # Disabled because fakeroot hangs in a Docker container
+          #- ciready/archlinux:base-devel-ci-c
 
           - ciready/almalinux:8-ci-c
           - ciready/almalinux:9-ci-c

--- a/.github/workflows/packaging-qa-os-matrix-small.yml
+++ b/.github/workflows/packaging-qa-os-matrix-small.yml
@@ -44,7 +44,8 @@ jobs:
     strategy:
       matrix:
         container:
-          - ciready/archlinux:base-devel-ci-c
+          # Disabled because fakeroot hangs in a Docker container
+          #- ciready/archlinux:base-devel-ci-c
 
           - ciready/centos:stream-9-ci-c
 

--- a/.github/workflows/publish-native-packages.yml
+++ b/.github/workflows/publish-native-packages.yml
@@ -32,7 +32,8 @@ jobs:
       max-parallel: 1
       matrix:
         container:
-          - ciready/archlinux:base-devel-ci-c
+          # Disabled because fakeroot hangs in a Docker container
+          #- ciready/archlinux:base-devel-ci-c
 
           - ciready/almalinux:8-ci-c
           - ciready/almalinux:9-ci-c

--- a/.github/workflows/release-qa-os-matrix-install-from-repo.yml
+++ b/.github/workflows/release-qa-os-matrix-install-from-repo.yml
@@ -39,7 +39,8 @@ jobs:
     strategy:
       matrix:
         container:
-          - archlinux:base-devel
+          # Disabled because fakeroot hangs in a Docker container
+          #- archlinux:base-devel
 
           - almalinux/8-base:latest
           - almalinux/9-base:latest


### PR DESCRIPTION
Packaging-related Actions for Arch Linux started failing because the whole process gets stuck on a hanged `fakeroot` process. This seems to be the relevant issue: https://github.com/docker/for-mac/issues/7331

Disabling Arch Linux packaging support until this issue is resolved.
